### PR TITLE
schema.json: Remove unneeded whitespace

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -505,7 +505,7 @@
           },
           "type": {
             "type": "string",
-            "description": " e.g. 'volunteering', 'presentation', 'talk', 'application', 'conference'"
+            "description": "e.g. 'volunteering', 'presentation', 'talk', 'application', 'conference'"
           }
         }
       }


### PR DESCRIPTION
Remove unneeded whitespace in the schema description to make it consistent with the rest of the document.