### PR TITLE
Add keywords property to interests section

### DIFF
--- a/docs/schema/schema.go
+++ b/docs/schema/schema.go
@@ -617,8 +617,13 @@ type Data struct {
 						Description string `json:"description"`
 					} `json:"name"`
 					Keywords struct {
-						Type        string `json:"type"`
-						Description string `json:"description"`
+						Type            string `json:"type"`
+						Description     string `json:"description"`
+						AdditionalItems bool   `json:"additionalItems"`
+						Items           struct {
+							Type        string `json:"type"`
+							Description string `json:"description"`
+						} `json:"items"`
 					} `json:"keywords"`
 				} `json:"properties"`
 			} `json:"items"`

--- a/docs/schema/schema.go
+++ b/docs/schema/schema.go
@@ -616,6 +616,10 @@ type Data struct {
 						Type        string `json:"type"`
 						Description string `json:"description"`
 					} `json:"name"`
+					Keywords struct {
+						Type        string `json:"type"`
+						Description string `json:"description"`
+					} `json:"keywords"`
 				} `json:"properties"`
 			} `json:"items"`
 		} `json:"interests"`

--- a/schema.json
+++ b/schema.json
@@ -612,7 +612,11 @@
         "properties": {
           "name": {
             "type": "string",
-            "description": "e.g. Philosophy"
+            "description": "e.g. Machine Learning"
+          },
+          "keywords": {
+            "type": "string",
+            "description": "e.g. Neural Networks, Convoluted Neural Networks"
           }
         }
       }

--- a/schema.json
+++ b/schema.json
@@ -613,14 +613,19 @@
           "name": {
             "type": "string",
             "description": "e.g. Machine Learning"
-          },
+          }
+        },
           "keywords": {
-            "type": "string",
-            "description": "e.g. Neural Networks, Convoluted Neural Networks"
+            "type": "array",
+            "description": "Specify keywords associated with the particular interest",
+            "additionalItems": false,
+            "items": {
+              "type": "string",
+              "description": "e.g. Neural Networks, Convoluted Neural Networks"
+            }
           }
         }
-      }
-    },
+      },
     "meta": {
       "type": "object",
       "description": "The schema version and any other tooling configuration lives here",


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds keywords property to interests section to allow for examples/clarification of interests.

**Which issue this PR fixes**:
fixes #3 
