### PR TITLE
Add date format to lastModified meta subsection

### DIFF
--- a/docs/schema/schema.go
+++ b/docs/schema/schema.go
@@ -635,6 +635,7 @@ type Data struct {
 				LastModified struct {
 					Type        string `json:"type"`
 					Description string `json:"description"`
+					Format      string `json:"format"`
 				} `json:"lastModified"`
 			} `json:"properties"`
 		} `json:"meta"`

--- a/schema.json
+++ b/schema.json
@@ -632,7 +632,8 @@
         },
         "lastModified": {
           "type": "string",
-          "description": "Using ISO 8601 with YYYY-MM-DDThh:mm:ss"
+          "description": "Using ISO 8601 with YYYY-MM-DDThh:mm:ss",
+          "format": "date"
         }
       }
     }

--- a/schema.json
+++ b/schema.json
@@ -632,7 +632,7 @@
         },
         "lastModified": {
           "type": "string",
-          "description": "Using ISO 8601 with YYYY-MM-DDThh:mm:ss",
+          "description": "e.g. 2017-06-29T15:53:00 - [resume.json uses the ISO 8601 date standard]",
           "format": "date"
         }
       }


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds missing date format to the lastModified subsection of the meta section

**Which issue this PR fixes**:
fixes #44 