### PR TITLE
Generate schema.json from Go struct

### DIFF
--- a/cmd/resumic/main.go
+++ b/cmd/resumic/main.go
@@ -7,8 +7,8 @@ import (
 	"log"
 	"os"
 
-	"github.com/erbesharat/schema/schema"
 	"github.com/resumic/schema/cmd/resumic/validate"
+	"github.com/resumic/schema/schema"
 )
 
 func main() {

--- a/cmd/resumic/main.go
+++ b/cmd/resumic/main.go
@@ -1,14 +1,51 @@
 package main
 
 import (
+	"encoding/json"
 	"flag"
+	"fmt"
+	"log"
+	"os"
 
+	"github.com/erbesharat/schema/schema"
 	"github.com/resumic/schema/cmd/resumic/validate"
 )
 
 func main() {
 	var doc string
+	var schemaFile string
 	flag.StringVar(&doc, "doc", "../../examples/invalid/invalid_email.json", "Example file")
+	flag.StringVar(&schemaFile, "schema", "./schema.json", "Generate JSON Schema")
 	flag.Parse()
-	validate.ValidateJSON(doc)
+
+	// Verify that a subcommand has been provided
+	if len(flag.Args()) < 1 {
+		fmt.Println("subcommand is required")
+		os.Exit(1)
+	}
+	switch flag.Args()[0] {
+	case "validate":
+		validate.ValidateJSON(doc)
+	case "schema":
+		schema, err := schema.GetSchema()
+		if err != nil {
+			log.Fatalf("Couldn't get the schema struct: %s", err)
+		}
+		json, err := json.Marshal(schema)
+		if err != nil {
+			log.Fatal("couldn't parse the schema")
+		}
+		file, err := os.Create(schemaFile)
+		defer file.Close()
+		if err != nil {
+			log.Fatal("couldn't create the schema file")
+		}
+		_, err = file.Write(json)
+		if err != nil {
+			log.Fatal("couldn't write the schema content to given the schema file")
+		}
+		log.Printf("Schema file created successfully: %s", file.Name())
+	default:
+		log.Fatalf("Unsupported subcommands. Please check --help for commands list")
+	}
 }

--- a/cmd/resumic/main.go
+++ b/cmd/resumic/main.go
@@ -11,11 +11,31 @@ import (
 	"github.com/resumic/schema/schema"
 )
 
+// GenerateSchema generates the schema.json file
+func GenerateSchema(schemaFile string) {
+	schema, err := schema.GetSchema()
+	if err != nil {
+		log.Fatalf("Couldn't get the schema struct: %s", err)
+	}
+	json, err := json.Marshal(schema)
+	if err != nil {
+		log.Fatal("couldn't parse the schema")
+	}
+	file, err := os.Create(schemaFile)
+	defer file.Close()
+	if err != nil {
+		log.Fatal("couldn't create the schema file")
+	}
+	_, err = file.Write(json)
+	if err != nil {
+		log.Fatal("couldn't write the schema content to given the schema file")
+	}
+	log.Printf("Schema file created successfully: %s", file.Name())
+}
+
 func main() {
-	var doc string
-	var schemaFile string
-	flag.StringVar(&doc, "doc", "../../examples/invalid/invalid_email.json", "Example file")
-	flag.StringVar(&schemaFile, "schema", "./schema.json", "Generate JSON Schema")
+	doc := flag.String("doc", "../../examples/invalid/invalid_email.json", "Example file")
+	schemaFile := flag.String("schema", "./schema.json", "Generate JSON Schema")
 	flag.Parse()
 
 	// Verify that a subcommand has been provided
@@ -25,26 +45,9 @@ func main() {
 	}
 	switch flag.Args()[0] {
 	case "validate":
-		validate.ValidateJSON(doc)
+		validate.ValidateJSON(*doc)
 	case "schema":
-		schema, err := schema.GetSchema()
-		if err != nil {
-			log.Fatalf("Couldn't get the schema struct: %s", err)
-		}
-		json, err := json.Marshal(schema)
-		if err != nil {
-			log.Fatal("couldn't parse the schema")
-		}
-		file, err := os.Create(schemaFile)
-		defer file.Close()
-		if err != nil {
-			log.Fatal("couldn't create the schema file")
-		}
-		_, err = file.Write(json)
-		if err != nil {
-			log.Fatal("couldn't write the schema content to given the schema file")
-		}
-		log.Printf("Schema file created successfully: %s", file.Name())
+		GenerateSchema(*schemaFile)
 	default:
 		log.Fatalf("Unsupported subcommands. Please check --help for commands list")
 	}

--- a/cmd/resumic/tests/validator_test.go
+++ b/cmd/resumic/tests/validator_test.go
@@ -13,7 +13,7 @@ import (
 func TestValidatorValidExamples(t *testing.T) {
 	files := run("../../../examples/valid")
 	for _, file := range files {
-		fmt.Println("In %s:", file)
+		fmt.Printf("In %s:", file)
 		result := validate.ValidateJSON(file)
 		if result != true {
 			t.Errorf("Expected valid state, got error")
@@ -26,7 +26,7 @@ func TestValidatorValidExamples(t *testing.T) {
 func TestValidatorInvalidExamples(t *testing.T) {
 	files := run("../../../examples/invalid")
 	for _, file := range files {
-		fmt.Println("In %s:", file)
+		fmt.Printf("In %s:", file)
 		result := validate.ValidateJSON(file)
 		if result != false {
 			t.Errorf("Expected invalid state, got valid")

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1,0 +1,694 @@
+package schema
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"os"
+)
+
+type Schema struct {
+	Schema               string
+	Title                string
+	Type                 string
+	AdditionalProperties bool
+	Properties           struct {
+		Core struct {
+			Type                 string
+			AdditionalProperties bool
+			Properties           struct {
+				Name struct {
+					Type        string
+					Description string
+				}
+				Title struct {
+					Type        string
+					Description string
+				}
+				Image struct {
+					Type        string
+					Description string
+				}
+				Email struct {
+					Type        string
+					Description string
+					Format      string
+				}
+				Phone struct {
+					Type        string
+					Description string
+				}
+				URL struct {
+					Type        string
+					Format      string
+					Description string
+				}
+				Summary struct {
+					Type        string
+					Format      string
+					Description string
+				}
+				CurrentLocation struct {
+					Type        string
+					Format      string
+					Description string
+					Properties  struct {
+						Lat struct {
+							Type string
+						}
+						Long struct {
+							Type string
+						}
+					}
+				}
+				PermanentLocation struct {
+					Type        string
+					Format      string
+					Description string
+					Properties  struct {
+						Lat struct {
+							Type string
+						}
+						Long struct {
+							Type string
+						}
+					}
+				}
+			}
+		}
+		Work struct {
+			Type            string
+			AdditionalItems bool
+			Items           struct {
+				Type                 string
+				AdditionalProperties bool
+				Properties           struct {
+					Name struct {
+						Type        string
+						Description string
+					}
+					Description struct {
+						Type        string
+						Description string
+					}
+					Position struct {
+						Type        string
+						Description string
+					}
+					Location struct {
+						Type        string
+						Format      string
+						Description string
+						Properties  struct {
+							Lat struct {
+								Type string
+							}
+							Long struct {
+								Type string
+							}
+						}
+					}
+					URL struct {
+						Type        string
+						Description string
+						Format      string
+					}
+					StartDate struct {
+						Type        string
+						Description string
+						Format      string
+					}
+					EndDate struct {
+						Type        string
+						Description string
+						Format      string
+					}
+					Summary struct {
+						Type        string
+						Description string
+					}
+					Highlights struct {
+						Type            string
+						Description     string
+						AdditionalItems bool
+						Items           struct {
+							Type        string
+							Description string
+						}
+					}
+				}
+			}
+		}
+		Education struct {
+			Type            string
+			AdditionalItems bool
+			Items           struct {
+				Type                 string
+				AdditionalProperties bool
+				Properties           struct {
+					Institution struct {
+						Type        string
+						Description string
+					}
+					Location struct {
+						Type        string
+						Format      string
+						Description string
+						Properties  struct {
+							Lat struct {
+								Type string
+							}
+							Long struct {
+								Type string
+							}
+						}
+					}
+					Area struct {
+						Type        string
+						Description string
+					}
+					StudyType struct {
+						Type        string
+						Description string
+					}
+					StartDate struct {
+						Type        string
+						Description string
+						Format      string
+					}
+					EndDate struct {
+						Type        string
+						Description string
+						Format      string
+					}
+					Score struct {
+						Type                 string
+						AdditionalProperties bool
+						Properties           struct {
+							Scoretype struct {
+								Type        string
+								Description string
+							}
+							Scorevalue struct {
+								Type        string
+								Description string
+							}
+						}
+					}
+					Courses struct {
+						Type            string
+						Description     string
+						AdditionalItems bool
+						Items           struct {
+							Type        string
+							Description string
+						}
+					}
+					Honors struct {
+						Type            string
+						Description     string
+						AdditionalItems bool
+						Items           struct {
+							Type        string
+							Description string
+						}
+					}
+				}
+			}
+		}
+		Volunteer struct {
+			Type            string
+			AdditionalItems bool
+			Items           struct {
+				Type                 string
+				AdditionalProperties bool
+				Properties           struct {
+					Organization struct {
+						Type        string
+						Description string
+					}
+					Position struct {
+						Type        string
+						Description string
+					}
+					Location struct {
+						Type        string
+						Format      string
+						Description string
+						Properties  struct {
+							Lat struct {
+								Type string
+							}
+							Long struct {
+								Type string
+							}
+						}
+					}
+					URL struct {
+						Type        string
+						Description string
+						Format      string
+					}
+					StartDate struct {
+						Type        string
+						Description string
+						Format      string
+					}
+					EndDate struct {
+						Type        string
+						Description string
+						Format      string
+					}
+					Summary struct {
+						Type        string
+						Description string
+					}
+					Highlights struct {
+						Type            string
+						Description     string
+						AdditionalItems bool
+						Items           struct {
+							Type        string
+							Description string
+						}
+					}
+				}
+			}
+		}
+		Publications struct {
+			Type            string
+			Description     string
+			AdditionalItems bool
+			Items           struct {
+				Type                 string
+				AdditionalProperties bool
+				Properties           struct {
+					Name struct {
+						Type        string
+						Description string
+					}
+					Publisher struct {
+						Type        string
+						Description string
+					}
+					ReleaseDate struct {
+						Type        string
+						Description string
+					}
+					Resources struct {
+						Type            string
+						Description     string
+						AdditionalItems bool
+						URL             struct {
+							Type        string
+							Format      string
+							Description string
+						}
+						Label struct {
+							Type        string
+							Description string
+						}
+					}
+					URL struct {
+						Type        string
+						Format      string
+						Description string
+					}
+					Summary struct {
+						Type        string
+						Description string
+					}
+				}
+			}
+		}
+		Legal struct {
+			Type            string
+			Description     string
+			AdditionalItems bool
+			Items           struct {
+				Type                 string
+				AdditionalProperties bool
+				Properties           struct {
+					Name struct {
+						Type        string
+						Description string
+					}
+					LegalType struct {
+						Type        string
+						Description string
+					}
+					Description struct {
+						Type        string
+						Description string
+					}
+					ApplicationDate struct {
+						Type        string
+						Description string
+						Format      string
+					}
+					GrantDate struct {
+						Type        string
+						Description string
+						Format      string
+					}
+					EndDate struct {
+						Type        string
+						Description string
+						Format      string
+					}
+					Resources struct {
+						Type            string
+						Description     string
+						AdditionalItems bool
+						URL             struct {
+							Type        string
+							Format      string
+							Description string
+						}
+						Label struct {
+							Type        string
+							Description string
+						}
+					}
+					IDNumber struct {
+						Type        string
+						Description string
+					}
+				}
+			}
+		}
+		Skills struct {
+			Type            string
+			Description     string
+			AdditionalItems bool
+			Items           struct {
+				Type                 string
+				AdditionalProperties bool
+				Properties           struct {
+					Name struct {
+						Type        string
+						Description string
+					}
+					Keyword struct {
+						Type            string
+						Description     string
+						AdditionalItems bool
+						Items           struct {
+							Type                 string
+							AdditionalProperties bool
+							Properties           struct {
+								Name struct {
+									Type        string
+									Description string
+								}
+								Score struct {
+									Type        string
+									Description string
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+		Awards struct {
+			Type            string
+			Description     string
+			AdditionalItems bool
+			Items           struct {
+				Type                 string
+				AdditionalProperties bool
+				Properties           struct {
+					Title struct {
+						Type        string
+						Description string
+					}
+					Date struct {
+						Type        string
+						Description string
+						Format      string
+					}
+					Awarder struct {
+						Type        string
+						Description string
+					}
+					Summary struct {
+						Type        string
+						Description string
+					}
+				}
+			}
+		}
+		Projects struct {
+			Type            string
+			Description     string
+			AdditionalItems bool
+			Items           struct {
+				Type                 string
+				AdditionalProperties bool
+				Properties           struct {
+					Name struct {
+						Type        string
+						Description string
+					}
+					Location struct {
+						Type        string
+						Format      string
+						Description string
+						Properties  struct {
+							Lat struct {
+								Type string
+							}
+							Long struct {
+								Type string
+							}
+						}
+					}
+					Description struct {
+						Type        string
+						Description string
+					}
+					Highlights struct {
+						Type            string
+						Description     string
+						AdditionalItems bool
+						Items           struct {
+							Type        string
+							Description string
+						}
+					}
+					Keywords struct {
+						Type            string
+						Description     string
+						AdditionalItems bool
+						Items           struct {
+							Type        string
+							Description string
+						}
+					}
+					StartDate struct {
+						Type        string
+						Description string
+						Format      string
+					}
+					EndDate struct {
+						Type        string
+						Description string
+						Format      string
+					}
+					Resources struct {
+						Type            string
+						Description     string
+						AdditionalItems bool
+						URL             struct {
+							Type        string
+							Format      string
+							Description string
+						}
+						Label struct {
+							Type        string
+							Description string
+						}
+					}
+					URL struct {
+						Type        string
+						Format      string
+						Description string
+					}
+					Roles struct {
+						Type            string
+						Description     string
+						AdditionalItems bool
+						Items           struct {
+							Type        string
+							Description string
+						}
+					}
+					Entity struct {
+						Type        string
+						Description string
+					}
+					Type struct {
+						Type        string
+						Description string
+					}
+				}
+			}
+		}
+		Certificates struct {
+			Type            string
+			AdditionalItems bool
+			Items           struct {
+				Type                 string
+				AdditionalProperties bool
+				Properties           struct {
+					Code struct {
+						Type        string
+						Description string
+					}
+					Name struct {
+						Type        string
+						Description string
+					}
+					Website struct {
+						Type        string
+						Description string
+						Format      string
+					}
+					Verification struct {
+						Type        string
+						Description string
+						Format      string
+					}
+					GrantDate struct {
+						Type        string
+						Description string
+						Format      string
+					}
+					Score struct {
+						Type        string
+						Description string
+					}
+					EndDate struct {
+						Type        string
+						Description string
+						Format      string
+					}
+					DoesNotExpire struct {
+						Type   string
+						Format string
+					}
+				}
+			}
+		}
+		References struct {
+			Type            string
+			Description     string
+			AdditionalItems bool
+			Items           struct {
+				Type                 string
+				AdditionalProperties bool
+				Properties           struct {
+					Name struct {
+						Type        string
+						Description string
+					}
+					Company struct {
+						Type        string
+						Description string
+					}
+					Position struct {
+						Type        string
+						Description string
+					}
+					Reference struct {
+						Type        string
+						Description string
+					}
+				}
+			}
+		}
+		Languages struct {
+			Type            string
+			Description     string
+			AdditionalItems bool
+			Items           struct {
+				Type                 string
+				AdditionalProperties bool
+				Properties           struct {
+					Language struct {
+						Type        string
+						Description string
+					}
+					Score struct {
+						Type        string
+						Description string
+					}
+				}
+			}
+		}
+		Interests struct {
+			Type            string
+			Description     string
+			AdditionalItems bool
+			Items           struct {
+				Type                 string
+				AdditionalProperties bool
+				Properties           struct {
+					Name struct {
+						Type        string
+						Description string
+					}
+				}
+				Keywords struct {
+					Type            string
+					Description     string
+					AdditionalItems bool
+					Items           struct {
+						Type        string
+						Description string
+					}
+				}
+			}
+		}
+		Meta struct {
+			Type                 string
+			Description          string
+			AdditionalProperties bool
+			Properties           struct {
+				Canonical struct {
+					Type        string
+					Description string
+				}
+				Version struct {
+					Type        string
+					Description string
+				}
+				LastModified struct {
+					Type        string
+					Description string
+					Format      string
+				}
+			}
+		}
+	}
+}
+
+func GetDefaultSchema() (Schema, error) {
+	valuesFile, err := os.Open("./schema.json")
+	if err != nil {
+		return Schema{}, err
+	}
+	defer valuesFile.Close()
+
+	values, err := ioutil.ReadAll(valuesFile)
+	if err != nil {
+		return Schema{}, err
+	}
+	schema := Schema{}
+	err = json.Unmarshal(values, &schema)
+	return schema, nil
+}
+
+func GetSchema() Schema {
+	return Schema{}
+}

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -6,49 +6,49 @@ import (
 	"os"
 )
 
+// Schema fields
+
 type StandardField struct {
 	Type        string `json:"type"`
 	Description string `json:"description"`
 	Format      string `json:"format,omitempty"`
 }
 
+type Location struct {
+	Type        string `json:"type"`
+	Format      string `json:"format"`
+	Description string `json:"description"`
+	Properties  struct {
+		Lat struct {
+			Type string `json:"type"`
+		} `json:"lat"`
+		Long struct {
+			Type string `json:"type"`
+		} `json:"long"`
+	} `json:"properties"`
+}
+
+type Highlights struct {
+	Type            string        `json:"type"`
+	Description     string        `json:"description"`
+	AdditionalItems bool          `json:"additionalItems"`
+	Items           StandardField `json:"items"`
+}
+
+// Main properties
 type Core struct {
 	Type                 string `json:"type"`
 	AdditionalProperties bool   `json:"additionalProperties"`
 	Properties           struct {
-		Name            StandardField `json:"name"`
-		Title           StandardField `json:"title"`
-		Image           StandardField `json:"image"`
-		Email           StandardField `json:"email"`
-		Phone           StandardField `json:"phone"`
-		URL             StandardField `json:"url"`
-		Summary         StandardField `json:"summary"`
-		CurrentLocation struct {
-			Type        string `json:"type"`
-			Format      string `json:"format"`
-			Description string `json:"description"`
-			Properties  struct {
-				Lat struct {
-					Type string `json:"type"`
-				} `json:"lat"`
-				Long struct {
-					Type string `json:"type"`
-				} `json:"long"`
-			} `json:"properties"`
-		} `json:"currentLocation"`
-		PermanentLocation struct {
-			Type        string `json:"type"`
-			Format      string `json:"format"`
-			Description string `json:"description"`
-			Properties  struct {
-				Lat struct {
-					Type string `json:"type"`
-				} `json:"lat"`
-				Long struct {
-					Type string `json:"type"`
-				} `json:"long"`
-			} `json:"properties"`
-		} `json:"permanentLocation"`
+		Name              StandardField `json:"name"`
+		Title             StandardField `json:"title"`
+		Image             StandardField `json:"image"`
+		Email             StandardField `json:"email"`
+		Phone             StandardField `json:"phone"`
+		URL               StandardField `json:"url"`
+		Summary           StandardField `json:"summary"`
+		CurrentLocation   Location      `json:"currentLocation"`
+		PermanentLocation Location      `json:"permanentLocation"`
 	} `json:"properties"`
 }
 
@@ -62,29 +62,12 @@ type Work struct {
 			Name        StandardField `json:"name"`
 			Description StandardField `json:"description"`
 			Position    StandardField `json:"position"`
-			Location    struct {
-				Type        string `json:"type"`
-				Format      string `json:"format"`
-				Description string `json:"description"`
-				Properties  struct {
-					Lat struct {
-						Type string `json:"type"`
-					} `json:"lat"`
-					Long struct {
-						Type string `json:"type"`
-					} `json:"long"`
-				} `json:"properties"`
-			} `json:"location"`
-			URL        StandardField `json:"url"`
-			StartDate  StandardField `json:"startDate"`
-			EndDate    StandardField `json:"endDate"`
-			Summary    StandardField `json:"summary"`
-			Highlights struct {
-				Type            string        `json:"type"`
-				Description     string        `json:"description"`
-				AdditionalItems bool          `json:"additionalItems"`
-				Items           StandardField `json:"items"`
-			} `json:"highlights"`
+			Location    Location      `json:"location"`
+			URL         StandardField `json:"url"`
+			StartDate   StandardField `json:"startDate"`
+			EndDate     StandardField `json:"endDate"`
+			Summary     StandardField `json:"summary"`
+			Highlights  Highlights    `json:"highlights"`
 		} `json:"properties"`
 	} `json:"items"`
 }
@@ -97,24 +80,12 @@ type Education struct {
 		AdditionalProperties bool   `json:"additionalProperties"`
 		Properties           struct {
 			Institution StandardField `json:"institution"`
-			Location    struct {
-				Type        string `json:"type"`
-				Format      string `json:"format"`
-				Description string `json:"description"`
-				Properties  struct {
-					Lat struct {
-						Type string `json:"type"`
-					} `json:"lat"`
-					Long struct {
-						Type string `json:"type"`
-					} `json:"long"`
-				} `json:"properties"`
-			} `json:"location"`
-			Area      StandardField `json:"area"`
-			StudyType StandardField `json:"studyType"`
-			StartDate StandardField `json:"startDate"`
-			EndDate   StandardField `json:"endDate"`
-			Score     struct {
+			Location    Location      `json:"location"`
+			Area        StandardField `json:"area"`
+			StudyType   StandardField `json:"studyType"`
+			StartDate   StandardField `json:"startDate"`
+			EndDate     StandardField `json:"endDate"`
+			Score       struct {
 				Type                 string `json:"type"`
 				AdditionalProperties bool   `json:"additionalProperties"`
 				Properties           struct {
@@ -147,29 +118,12 @@ type Volunteer struct {
 		Properties           struct {
 			Organization StandardField `json:"organization"`
 			Position     StandardField `json:"position"`
-			Location     struct {
-				Type        string `json:"type"`
-				Format      string `json:"format"`
-				Description string `json:"description"`
-				Properties  struct {
-					Lat struct {
-						Type string `json:"type"`
-					} `json:"lat"`
-					Long struct {
-						Type string `json:"type"`
-					} `json:"long"`
-				} `json:"properties"`
-			} `json:"location"`
-			URL        StandardField `json:"url"`
-			StartDate  StandardField `json:"startDate"`
-			EndDate    StandardField `json:"endDate"`
-			Summary    StandardField `json:"summary"`
-			Highlights struct {
-				Type            string        `json:"type"`
-				Description     string        `json:"description"`
-				AdditionalItems bool          `json:"additionalItems"`
-				Items           StandardField `json:"items"`
-			} `json:"highlights"`
+			Location     Location      `json:"location"`
+			URL          StandardField `json:"url"`
+			StartDate    StandardField `json:"startDate"`
+			EndDate      StandardField `json:"endDate"`
+			Summary      StandardField `json:"summary"`
+			Highlights   Highlights    `json:"highlights"`
 		} `json:"properties"`
 	} `json:"items"`
 }
@@ -274,28 +228,11 @@ type Projects struct {
 		Type                 string `json:"type"`
 		AdditionalProperties bool   `json:"additionalProperties"`
 		Properties           struct {
-			Name     StandardField `json:"name"`
-			Location struct {
-				Type        string `json:"type"`
-				Format      string `json:"format"`
-				Description string `json:"description"`
-				Properties  struct {
-					Lat struct {
-						Type string `json:"type"`
-					} `json:"lat"`
-					Long struct {
-						Type string `json:"type"`
-					} `json:"long"`
-				} `json:"properties"`
-			} `json:"location"`
+			Name        StandardField `json:"name"`
+			Location    Location      `json:"location"`
 			Description StandardField `json:"description"`
-			Highlights  struct {
-				Type            string        `json:"type"`
-				Description     string        `json:"description"`
-				AdditionalItems bool          `json:"additionalItems"`
-				Items           StandardField `json:"items"`
-			} `json:"highlights"`
-			Keywords struct {
+			Highlights  Highlights    `json:"highlights"`
+			Keywords    struct {
 				Type            string        `json:"type"`
 				Description     string        `json:"description"`
 				AdditionalItems bool          `json:"additionalItems"`

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -11,390 +11,419 @@ type StandardField struct {
 	Description string `json:"description"`
 	Format      string `json:"format,omitempty"`
 }
+
+type Core struct {
+	Type                 string `json:"type"`
+	AdditionalProperties bool   `json:"additionalProperties"`
+	Properties           struct {
+		Name            StandardField `json:"name"`
+		Title           StandardField `json:"title"`
+		Image           StandardField `json:"image"`
+		Email           StandardField `json:"email"`
+		Phone           StandardField `json:"phone"`
+		Url             StandardField `json:"url"`
+		Summary         StandardField `json:"summary"`
+		CurrentLocation struct {
+			Type        string `json:"type"`
+			Format      string `json:"format"`
+			Description string `json:"description"`
+			Properties  struct {
+				Lat struct {
+					Type string `json:"type"`
+				} `json:"lat"`
+				Long struct {
+					Type string `json:"type"`
+				} `json:"long"`
+			} `json:"properties"`
+		} `json:"currentLocation"`
+		PermanentLocation struct {
+			Type        string `json:"type"`
+			Format      string `json:"format"`
+			Description string `json:"description"`
+			Properties  struct {
+				Lat struct {
+					Type string `json:"type"`
+				} `json:"lat"`
+				Long struct {
+					Type string `json:"type"`
+				} `json:"long"`
+			} `json:"properties"`
+		} `json:"permanentLocation"`
+	} `json:"properties"`
+}
+
+type Work struct {
+	Type            string `json:"type"`
+	AdditionalItems bool   `json:"additionalItems"`
+	Items           struct {
+		Type                 string `json:"type"`
+		AdditionalProperties bool   `json:"additionalProperties"`
+		Properties           struct {
+			Name        StandardField `json:"name"`
+			Description StandardField `json:"description"`
+			Position    StandardField `json:"position"`
+			Location    struct {
+				Type        string `json:"type"`
+				Format      string `json:"format"`
+				Description string `json:"description"`
+				Properties  struct {
+					Lat struct {
+						Type string `json:"type"`
+					} `json:"lat"`
+					Long struct {
+						Type string `json:"type"`
+					} `json:"long"`
+				} `json:"properties"`
+			} `json:"location"`
+			Url        StandardField `json:"url"`
+			StartDate  StandardField `json:"startDate"`
+			EndDate    StandardField `json:"endDate"`
+			Summary    StandardField `json:"summary"`
+			Highlights struct {
+				Type            string        `json:"type"`
+				Description     string        `json:"description"`
+				AdditionalItems bool          `json:"additionalItems"`
+				Items           StandardField `json:"items"`
+			} `json:"highlights"`
+		} `json:"properties"`
+	} `json:"items"`
+}
+
+type Education struct {
+	Type            string `json:"type"`
+	AdditionalItems bool   `json:"additionalItems"`
+	Items           struct {
+		Type                 string `json:"type"`
+		AdditionalProperties bool   `json:"additionalProperties"`
+		Properties           struct {
+			Institution StandardField `json:"institution"`
+			Location    struct {
+				Type        string `json:"type"`
+				Format      string `json:"format"`
+				Description string `json:"description"`
+				Properties  struct {
+					Lat struct {
+						Type string `json:"type"`
+					} `json:"lat"`
+					Long struct {
+						Type string `json:"type"`
+					} `json:"long"`
+				} `json:"properties"`
+			} `json:"location"`
+			Area      StandardField `json:"area"`
+			StudyType StandardField `json:"studyType"`
+			StartDate StandardField `json:"startDate"`
+			EndDate   StandardField `json:"endDate"`
+			Score     struct {
+				Type                 string `json:"type"`
+				AdditionalProperties bool   `json:"additionalProperties"`
+				Properties           struct {
+					Scoretype  StandardField `json:"scoretype"`
+					Scorevalue StandardField `json:"scorevalue"`
+				} `json:"properties"`
+			} `json:"score"`
+			Courses struct {
+				Type            string        `json:"type"`
+				Description     string        `json:"description"`
+				AdditionalItems bool          `json:"additionalItems"`
+				Items           StandardField `json:"items"`
+			} `json:"courses"`
+			Honors struct {
+				Type            string        `json:"type"`
+				Description     string        `json:"description"`
+				AdditionalItems bool          `json:"additionalItems"`
+				Items           StandardField `json:"items"`
+			} `json:"honors"`
+		} `json:"properties"`
+	} `json:"items"`
+}
+
+type Volunteer struct {
+	Type            string `json:"type"`
+	AdditionalItems bool   `json:"additionalItems"`
+	Items           struct {
+		Type                 string `json:"type"`
+		AdditionalProperties bool   `json:"additionalProperties"`
+		Properties           struct {
+			Organization StandardField `json:"organization"`
+			Position     StandardField `json:"position"`
+			Location     struct {
+				Type        string `json:"type"`
+				Format      string `json:"format"`
+				Description string `json:"description"`
+				Properties  struct {
+					Lat struct {
+						Type string `json:"type"`
+					} `json:"lat"`
+					Long struct {
+						Type string `json:"type"`
+					} `json:"long"`
+				} `json:"properties"`
+			} `json:"location"`
+			Url        StandardField `json:"url"`
+			StartDate  StandardField `json:"startDate"`
+			EndDate    StandardField `json:"endDate"`
+			Summary    StandardField `json:"summary"`
+			Highlights struct {
+				Type            string        `json:"type"`
+				Description     string        `json:"description"`
+				AdditionalItems bool          `json:"additionalItems"`
+				Items           StandardField `json:"items"`
+			} `json:"highlights"`
+		} `json:"properties"`
+	} `json:"items"`
+}
+
+type Publications struct {
+	Type            string `json:"type"`
+	Description     string `json:"description"`
+	AdditionalItems bool   `json:"additionalItems"`
+	Items           struct {
+		Type                 string `json:"type"`
+		AdditionalProperties bool   `json:"additionalProperties"`
+		Properties           struct {
+			Name        StandardField `json:"name"`
+			Publisher   StandardField `json:"publisher"`
+			ReleaseDate StandardField `json:"releaseDate"`
+			Resources   struct {
+				Type            string        `json:"type"`
+				Description     string        `json:"description"`
+				AdditionalItems bool          `json:"additionalItems"`
+				Url             StandardField `json:"url"`
+				Label           StandardField `json:"label"`
+			} `json:"resources"`
+			Url     StandardField `json:"url"`
+			Summary StandardField `json:"summary"`
+		} `json:"properties"`
+	} `json:"items"`
+}
+
+type Legal struct {
+	Type            string `json:"type"`
+	Description     string `json:"description"`
+	AdditionalItems bool   `json:"additionalItems"`
+	Items           struct {
+		Type                 string `json:"type"`
+		AdditionalProperties bool   `json:"additionalProperties"`
+		Properties           struct {
+			Name            StandardField `json:"name"`
+			LegalType       StandardField `json:"legalType"`
+			Description     StandardField `json:"description"`
+			ApplicationDate StandardField `json:"applicationDate"`
+			GrantDate       StandardField `json:"grantDate"`
+			EndDate         StandardField `json:"endDate"`
+			Resources       struct {
+				Type            string        `json:"type"`
+				Description     string        `json:"description"`
+				AdditionalItems bool          `json:"additionalItems"`
+				Url             StandardField `json:"url"`
+				Label           StandardField `json:"label"`
+			} `json:"resources"`
+			IdNumber StandardField `json:"idNumber"`
+		} `json:"properties"`
+	} `json:"items"`
+}
+
+type Skills struct {
+	Type            string `json:"type"`
+	Description     string `json:"description"`
+	AdditionalItems bool   `json:"additionalItems"`
+	Items           struct {
+		Type                 string `json:"type"`
+		AdditionalProperties bool   `json:"additionalProperties"`
+		Properties           struct {
+			Name    StandardField `json:"name"`
+			Keyword struct {
+				Type            string `json:"type"`
+				Description     string `json:"description"`
+				AdditionalItems bool   `json:"additionalItems"`
+				Items           struct {
+					Type                 string `json:"type"`
+					AdditionalProperties bool   `json:"additionalProperties"`
+					Properties           struct {
+						Name  StandardField `json:"name"`
+						Score StandardField `json:"score"`
+					} `json:"properties"`
+				} `json:"items"`
+			} `json:"keyword"`
+		} `json:"properties"`
+	} `json:"items"`
+}
+
+type Awards struct {
+	Type            string `json:"type"`
+	Description     string `json:"description"`
+	AdditionalItems bool   `json:"additionalItems"`
+	Items           struct {
+		Type                 string `json:"type"`
+		AdditionalProperties bool   `json:"additionalProperties"`
+		Properties           struct {
+			Title   StandardField `json:"title"`
+			Date    StandardField `json:"date"`
+			Awarder StandardField `json:"awarder"`
+			Summary StandardField `json:"summary"`
+		} `json:"properties"`
+	} `json:"items"`
+}
+
+type Projects struct {
+	Type            string `json:"type"`
+	Description     string `json:"description"`
+	AdditionalItems bool   `json:"additionalItems"`
+	Items           struct {
+		Type                 string `json:"type"`
+		AdditionalProperties bool   `json:"additionalProperties"`
+		Properties           struct {
+			Name     StandardField `json:"name"`
+			Location struct {
+				Type        string `json:"type"`
+				Format      string `json:"format"`
+				Description string `json:"description"`
+				Properties  struct {
+					Lat struct {
+						Type string `json:"type"`
+					} `json:"lat"`
+					Long struct {
+						Type string `json:"type"`
+					} `json:"long"`
+				} `json:"properties"`
+			} `json:"location"`
+			Description StandardField `json:"description"`
+			Highlights  struct {
+				Type            string        `json:"type"`
+				Description     string        `json:"description"`
+				AdditionalItems bool          `json:"additionalItems"`
+				Items           StandardField `json:"items"`
+			} `json:"highlights"`
+			Keywords struct {
+				Type            string        `json:"type"`
+				Description     string        `json:"description"`
+				AdditionalItems bool          `json:"additionalItems"`
+				Items           StandardField `json:"items"`
+			} `json:"keywords"`
+			StartDate StandardField `json:"startDate"`
+			EndDate   StandardField `json:"endDate"`
+			Resources struct {
+				Type            string        `json:"type"`
+				Description     string        `json:"description"`
+				AdditionalItems bool          `json:"additionalItems"`
+				Url             StandardField `json:"url"`
+				Label           StandardField `json:"label"`
+			} `json:"resources"`
+			Url   StandardField `json:"url"`
+			Roles struct {
+				Type            string        `json:"type"`
+				Description     string        `json:"description"`
+				AdditionalItems bool          `json:"additionalItems"`
+				Items           StandardField `json:"items"`
+			} `json:"roles"`
+			Entity StandardField `json:"entity"`
+			Type   StandardField `json:"type"`
+		} `json:"properties"`
+	} `json:"items"`
+}
+
+type Certificates struct {
+	Type            string `json:"type"`
+	AdditionalItems bool   `json:"additionalItems"`
+	Items           struct {
+		Type                 string `json:"type"`
+		AdditionalProperties bool   `json:"additionalProperties"`
+		Properties           struct {
+			Code          StandardField `json:"code"`
+			Name          StandardField `json:"name"`
+			Website       StandardField `json:"website"`
+			Verification  StandardField `json:"verification"`
+			GrantDate     StandardField `json:"grantDate"`
+			Score         StandardField `json:"score"`
+			EndDate       StandardField `json:"endDate"`
+			DoesNotExpire struct {
+				Type   string `json:"type"`
+				Format string `json:"format"`
+			} `json:"doesNotExpire"`
+		} `json:"properties"`
+	} `json:"items"`
+}
+
+type References struct {
+	Type            string `json:"type"`
+	Description     string `json:"description"`
+	AdditionalItems bool   `json:"additionalItems"`
+	Items           struct {
+		Type                 string `json:"type"`
+		AdditionalProperties bool   `json:"additionalProperties"`
+		Properties           struct {
+			Name      StandardField `json:"name"`
+			Company   StandardField `json:"company"`
+			Position  StandardField `json:"position"`
+			Reference StandardField `json:"reference"`
+		} `json:"properties"`
+	} `json:"items"`
+}
+
+type Languages struct {
+	Type            string `json:"type"`
+	Description     string `json:"description"`
+	AdditionalItems bool   `json:"additionalItems"`
+	Items           struct {
+		Type                 string `json:"type"`
+		AdditionalProperties bool   `json:"additionalProperties"`
+		Properties           struct {
+			Language StandardField `json:"language"`
+			Score    StandardField `json:"score"`
+		} `json:"properties"`
+	} `json:"items"`
+}
+
+type Interests struct {
+	Type            string `json:"type"`
+	AdditionalItems bool   `json:"additionalItems"`
+	Items           struct {
+		Type                 string `json:"type"`
+		AdditionalProperties bool   `json:"additionalProperties"`
+		Properties           struct {
+			Name     StandardField `json:"name"`
+			Keywords struct {
+				Type            string        `json:"type"`
+				Description     string        `json:"description"`
+				AdditionalItems bool          `json:"additionalItems"`
+				Items           StandardField `json:"items"`
+			} `json:"keywords"`
+		} `json:"properties"`
+	} `json:"items"`
+}
+
+type Meta struct {
+	Type                 string `json:"type"`
+	Description          string `json:"description"`
+	AdditionalProperties bool   `json:"additionalProperties"`
+	Properties           struct {
+		Canonical    StandardField `json:"canonical"`
+		Version      StandardField `json:"version"`
+		LastModified StandardField `json:"lastModified"`
+	} `json:"properties"`
+}
+
 type Schema struct {
 	Schema               string `json:"$schema"`
 	Title                string `json:"title"`
 	Type                 string `json:"type"`
 	AdditionalProperties bool   `json:"additionalProperties"`
 	Properties           struct {
-		Core struct {
-			Type                 string `json:"type"`
-			AdditionalProperties bool   `json:"additionalProperties"`
-			Properties           struct {
-				Name            StandardField `json:"name"`
-				Title           StandardField `json:"title"`
-				Image           StandardField `json:"image"`
-				Email           StandardField `json:"email"`
-				Phone           StandardField `json:"phone"`
-				Url             StandardField `json:"url"`
-				Summary         StandardField `json:"summary"`
-				CurrentLocation struct {
-					Type        string `json:"type"`
-					Format      string `json:"format"`
-					Description string `json:"description"`
-					Properties  struct {
-						Lat struct {
-							Type string `json:"type"`
-						} `json:"lat"`
-						Long struct {
-							Type string `json:"type"`
-						} `json:"long"`
-					} `json:"properties"`
-				} `json:"currentLocation"`
-				PermanentLocation struct {
-					Type        string `json:"type"`
-					Format      string `json:"format"`
-					Description string `json:"description"`
-					Properties  struct {
-						Lat struct {
-							Type string `json:"type"`
-						} `json:"lat"`
-						Long struct {
-							Type string `json:"type"`
-						} `json:"long"`
-					} `json:"properties"`
-				} `json:"permanentLocation"`
-			} `json:"properties"`
-		} `json:"core"`
-		Work struct {
-			Type            string `json:"type"`
-			AdditionalItems bool   `json:"additionalItems"`
-			Items           struct {
-				Type                 string `json:"type"`
-				AdditionalProperties bool   `json:"additionalProperties"`
-				Properties           struct {
-					Name        StandardField `json:"name"`
-					Description StandardField `json:"description"`
-					Position    StandardField `json:"position"`
-					Location    struct {
-						Type        string `json:"type"`
-						Format      string `json:"format"`
-						Description string `json:"description"`
-						Properties  struct {
-							Lat struct {
-								Type string `json:"type"`
-							} `json:"lat"`
-							Long struct {
-								Type string `json:"type"`
-							} `json:"long"`
-						} `json:"properties"`
-					} `json:"location"`
-					Url        StandardField `json:"url"`
-					StartDate  StandardField `json:"startDate"`
-					EndDate    StandardField `json:"endDate"`
-					Summary    StandardField `json:"summary"`
-					Highlights struct {
-						Type            string        `json:"type"`
-						Description     string        `json:"description"`
-						AdditionalItems bool          `json:"additionalItems"`
-						Items           StandardField `json:"items"`
-					} `json:"highlights"`
-				} `json:"properties"`
-			} `json:"items"`
-		} `json:"work"`
-		Education struct {
-			Type            string `json:"type"`
-			AdditionalItems bool   `json:"additionalItems"`
-			Items           struct {
-				Type                 string `json:"type"`
-				AdditionalProperties bool   `json:"additionalProperties"`
-				Properties           struct {
-					Institution StandardField `json:"institution"`
-					Location    struct {
-						Type        string `json:"type"`
-						Format      string `json:"format"`
-						Description string `json:"description"`
-						Properties  struct {
-							Lat struct {
-								Type string `json:"type"`
-							} `json:"lat"`
-							Long struct {
-								Type string `json:"type"`
-							} `json:"long"`
-						} `json:"properties"`
-					} `json:"location"`
-					Area      StandardField `json:"area"`
-					StudyType StandardField `json:"studyType"`
-					StartDate StandardField `json:"startDate"`
-					EndDate   StandardField `json:"endDate"`
-					Score     struct {
-						Type                 string `json:"type"`
-						AdditionalProperties bool   `json:"additionalProperties"`
-						Properties           struct {
-							Scoretype  StandardField `json:"scoretype"`
-							Scorevalue StandardField `json:"scorevalue"`
-						} `json:"properties"`
-					} `json:"score"`
-					Courses struct {
-						Type            string        `json:"type"`
-						Description     string        `json:"description"`
-						AdditionalItems bool          `json:"additionalItems"`
-						Items           StandardField `json:"items"`
-					} `json:"courses"`
-					Honors struct {
-						Type            string        `json:"type"`
-						Description     string        `json:"description"`
-						AdditionalItems bool          `json:"additionalItems"`
-						Items           StandardField `json:"items"`
-					} `json:"honors"`
-				} `json:"properties"`
-			} `json:"items"`
-		} `json:"education"`
-		Volunteer struct {
-			Type            string `json:"type"`
-			AdditionalItems bool   `json:"additionalItems"`
-			Items           struct {
-				Type                 string `json:"type"`
-				AdditionalProperties bool   `json:"additionalProperties"`
-				Properties           struct {
-					Organization StandardField `json:"organization"`
-					Position     StandardField `json:"position"`
-					Location     struct {
-						Type        string `json:"type"`
-						Format      string `json:"format"`
-						Description string `json:"description"`
-						Properties  struct {
-							Lat struct {
-								Type string `json:"type"`
-							} `json:"lat"`
-							Long struct {
-								Type string `json:"type"`
-							} `json:"long"`
-						} `json:"properties"`
-					} `json:"location"`
-					Url        StandardField `json:"url"`
-					StartDate  StandardField `json:"startDate"`
-					EndDate    StandardField `json:"endDate"`
-					Summary    StandardField `json:"summary"`
-					Highlights struct {
-						Type            string        `json:"type"`
-						Description     string        `json:"description"`
-						AdditionalItems bool          `json:"additionalItems"`
-						Items           StandardField `json:"items"`
-					} `json:"highlights"`
-				} `json:"properties"`
-			} `json:"items"`
-		} `json:"volunteer"`
-		Publications struct {
-			Type            string `json:"type"`
-			Description     string `json:"description"`
-			AdditionalItems bool   `json:"additionalItems"`
-			Items           struct {
-				Type                 string `json:"type"`
-				AdditionalProperties bool   `json:"additionalProperties"`
-				Properties           struct {
-					Name        StandardField `json:"name"`
-					Publisher   StandardField `json:"publisher"`
-					ReleaseDate StandardField `json:"releaseDate"`
-					Resources   struct {
-						Type            string        `json:"type"`
-						Description     string        `json:"description"`
-						AdditionalItems bool          `json:"additionalItems"`
-						Url             StandardField `json:"url"`
-						Label           StandardField `json:"label"`
-					} `json:"resources"`
-					Url     StandardField `json:"url"`
-					Summary StandardField `json:"summary"`
-				} `json:"properties"`
-			} `json:"items"`
-		} `json:"publications"`
-		Legal struct {
-			Type            string `json:"type"`
-			Description     string `json:"description"`
-			AdditionalItems bool   `json:"additionalItems"`
-			Items           struct {
-				Type                 string `json:"type"`
-				AdditionalProperties bool   `json:"additionalProperties"`
-				Properties           struct {
-					Name            StandardField `json:"name"`
-					LegalType       StandardField `json:"legalType"`
-					Description     StandardField `json:"description"`
-					ApplicationDate StandardField `json:"applicationDate"`
-					GrantDate       StandardField `json:"grantDate"`
-					EndDate         StandardField `json:"endDate"`
-					Resources       struct {
-						Type            string        `json:"type"`
-						Description     string        `json:"description"`
-						AdditionalItems bool          `json:"additionalItems"`
-						Url             StandardField `json:"url"`
-						Label           StandardField `json:"label"`
-					} `json:"resources"`
-					IdNumber StandardField `json:"idNumber"`
-				} `json:"properties"`
-			} `json:"items"`
-		} `json:"legal"`
-		Skills struct {
-			Type            string `json:"type"`
-			Description     string `json:"description"`
-			AdditionalItems bool   `json:"additionalItems"`
-			Items           struct {
-				Type                 string `json:"type"`
-				AdditionalProperties bool   `json:"additionalProperties"`
-				Properties           struct {
-					Name    StandardField `json:"name"`
-					Keyword struct {
-						Type            string `json:"type"`
-						Description     string `json:"description"`
-						AdditionalItems bool   `json:"additionalItems"`
-						Items           struct {
-							Type                 string `json:"type"`
-							AdditionalProperties bool   `json:"additionalProperties"`
-							Properties           struct {
-								Name  StandardField `json:"name"`
-								Score StandardField `json:"score"`
-							} `json:"properties"`
-						} `json:"items"`
-					} `json:"keyword"`
-				} `json:"properties"`
-			} `json:"items"`
-		} `json:"skills"`
-		Awards struct {
-			Type            string `json:"type"`
-			Description     string `json:"description"`
-			AdditionalItems bool   `json:"additionalItems"`
-			Items           struct {
-				Type                 string `json:"type"`
-				AdditionalProperties bool   `json:"additionalProperties"`
-				Properties           struct {
-					Title   StandardField `json:"title"`
-					Date    StandardField `json:"date"`
-					Awarder StandardField `json:"awarder"`
-					Summary StandardField `json:"summary"`
-				} `json:"properties"`
-			} `json:"items"`
-		} `json:"awards"`
-		Projects struct {
-			Type            string `json:"type"`
-			Description     string `json:"description"`
-			AdditionalItems bool   `json:"additionalItems"`
-			Items           struct {
-				Type                 string `json:"type"`
-				AdditionalProperties bool   `json:"additionalProperties"`
-				Properties           struct {
-					Name     StandardField `json:"name"`
-					Location struct {
-						Type        string `json:"type"`
-						Format      string `json:"format"`
-						Description string `json:"description"`
-						Properties  struct {
-							Lat struct {
-								Type string `json:"type"`
-							} `json:"lat"`
-							Long struct {
-								Type string `json:"type"`
-							} `json:"long"`
-						} `json:"properties"`
-					} `json:"location"`
-					Description StandardField `json:"description"`
-					Highlights  struct {
-						Type            string        `json:"type"`
-						Description     string        `json:"description"`
-						AdditionalItems bool          `json:"additionalItems"`
-						Items           StandardField `json:"items"`
-					} `json:"highlights"`
-					Keywords struct {
-						Type            string        `json:"type"`
-						Description     string        `json:"description"`
-						AdditionalItems bool          `json:"additionalItems"`
-						Items           StandardField `json:"items"`
-					} `json:"keywords"`
-					StartDate StandardField `json:"startDate"`
-					EndDate   StandardField `json:"endDate"`
-					Resources struct {
-						Type            string        `json:"type"`
-						Description     string        `json:"description"`
-						AdditionalItems bool          `json:"additionalItems"`
-						Url             StandardField `json:"url"`
-						Label           StandardField `json:"label"`
-					} `json:"resources"`
-					Url   StandardField `json:"url"`
-					Roles struct {
-						Type            string        `json:"type"`
-						Description     string        `json:"description"`
-						AdditionalItems bool          `json:"additionalItems"`
-						Items           StandardField `json:"items"`
-					} `json:"roles"`
-					Entity StandardField `json:"entity"`
-					Type   StandardField `json:"type"`
-				} `json:"properties"`
-			} `json:"items"`
-		} `json:"projects"`
-		Certificates struct {
-			Type            string `json:"type"`
-			AdditionalItems bool   `json:"additionalItems"`
-			Items           struct {
-				Type                 string `json:"type"`
-				AdditionalProperties bool   `json:"additionalProperties"`
-				Properties           struct {
-					Code          StandardField `json:"code"`
-					Name          StandardField `json:"name"`
-					Website       StandardField `json:"website"`
-					Verification  StandardField `json:"verification"`
-					GrantDate     StandardField `json:"grantDate"`
-					Score         StandardField `json:"score"`
-					EndDate       StandardField `json:"endDate"`
-					DoesNotExpire struct {
-						Type   string `json:"type"`
-						Format string `json:"format"`
-					} `json:"doesNotExpire"`
-				} `json:"properties"`
-			} `json:"items"`
-		} `json:"certificates"`
-		References struct {
-			Type            string `json:"type"`
-			Description     string `json:"description"`
-			AdditionalItems bool   `json:"additionalItems"`
-			Items           struct {
-				Type                 string `json:"type"`
-				AdditionalProperties bool   `json:"additionalProperties"`
-				Properties           struct {
-					Name      StandardField `json:"name"`
-					Company   StandardField `json:"company"`
-					Position  StandardField `json:"position"`
-					Reference StandardField `json:"reference"`
-				} `json:"properties"`
-			} `json:"items"`
-		} `json:"references"`
-		Languages struct {
-			Type            string `json:"type"`
-			Description     string `json:"description"`
-			AdditionalItems bool   `json:"additionalItems"`
-			Items           struct {
-				Type                 string `json:"type"`
-				AdditionalProperties bool   `json:"additionalProperties"`
-				Properties           struct {
-					Language StandardField `json:"language"`
-					Score    StandardField `json:"score"`
-				} `json:"properties"`
-			} `json:"items"`
-		} `json:"languages"`
-		Interests struct {
-			Type            string `json:"type"`
-			AdditionalItems bool   `json:"additionalItems"`
-			Items           struct {
-				Type                 string `json:"type"`
-				AdditionalProperties bool   `json:"additionalProperties"`
-				Properties           struct {
-					Name     StandardField `json:"name"`
-					Keywords struct {
-						Type            string        `json:"type"`
-						Description     string        `json:"description"`
-						AdditionalItems bool          `json:"additionalItems"`
-						Items           StandardField `json:"items"`
-					} `json:"keywords"`
-				} `json:"properties"`
-			} `json:"items"`
-		} `json:"interests"`
-		Meta struct {
-			Type                 string `json:"type"`
-			Description          string `json:"description"`
-			AdditionalProperties bool   `json:"additionalProperties"`
-			Properties           struct {
-				Canonical    StandardField `json:"canonical"`
-				Version      StandardField `json:"version"`
-				LastModified StandardField `json:"lastModified"`
-			} `json:"properties"`
-		} `json:"meta"`
+		Core         Core         `json:"core"`
+		Work         Work         `json:"work"`
+		Education    Education    `json:"education"`
+		Volunteer    Volunteer    `json:"volunteer"`
+		Publications Publications `json:"publications"`
+		Legal        Legal        `json:"legal"`
+		Skills       Skills       `json:"skills"`
+		Awards       Awards       `json:"awards"`
+		Projects     Projects     `json:"projects"`
+		Certificates Certificates `json:"certificates"`
+		References   References   `json:"references"`
+		Languages    Languages    `json:"languages"`
+		Interests    Interests    `json:"interests"`
+		Meta         Meta         `json:"meta"`
 	} `json:"properties"`
 }
 

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -21,7 +21,7 @@ type Core struct {
 		Image           StandardField `json:"image"`
 		Email           StandardField `json:"email"`
 		Phone           StandardField `json:"phone"`
-		Url             StandardField `json:"url"`
+		URL             StandardField `json:"url"`
 		Summary         StandardField `json:"summary"`
 		CurrentLocation struct {
 			Type        string `json:"type"`
@@ -75,7 +75,7 @@ type Work struct {
 					} `json:"long"`
 				} `json:"properties"`
 			} `json:"location"`
-			Url        StandardField `json:"url"`
+			URL        StandardField `json:"url"`
 			StartDate  StandardField `json:"startDate"`
 			EndDate    StandardField `json:"endDate"`
 			Summary    StandardField `json:"summary"`
@@ -160,7 +160,7 @@ type Volunteer struct {
 					} `json:"long"`
 				} `json:"properties"`
 			} `json:"location"`
-			Url        StandardField `json:"url"`
+			URL        StandardField `json:"url"`
 			StartDate  StandardField `json:"startDate"`
 			EndDate    StandardField `json:"endDate"`
 			Summary    StandardField `json:"summary"`
@@ -189,10 +189,10 @@ type Publications struct {
 				Type            string        `json:"type"`
 				Description     string        `json:"description"`
 				AdditionalItems bool          `json:"additionalItems"`
-				Url             StandardField `json:"url"`
+				URL             StandardField `json:"url"`
 				Label           StandardField `json:"label"`
 			} `json:"resources"`
-			Url     StandardField `json:"url"`
+			URL     StandardField `json:"url"`
 			Summary StandardField `json:"summary"`
 		} `json:"properties"`
 	} `json:"items"`
@@ -216,10 +216,10 @@ type Legal struct {
 				Type            string        `json:"type"`
 				Description     string        `json:"description"`
 				AdditionalItems bool          `json:"additionalItems"`
-				Url             StandardField `json:"url"`
+				URL             StandardField `json:"url"`
 				Label           StandardField `json:"label"`
 			} `json:"resources"`
-			IdNumber StandardField `json:"idNumber"`
+			IDNumber StandardField `json:"idNumber"`
 		} `json:"properties"`
 	} `json:"items"`
 }
@@ -307,10 +307,10 @@ type Projects struct {
 				Type            string        `json:"type"`
 				Description     string        `json:"description"`
 				AdditionalItems bool          `json:"additionalItems"`
-				Url             StandardField `json:"url"`
+				URL             StandardField `json:"url"`
 				Label           StandardField `json:"label"`
 			} `json:"resources"`
-			Url   StandardField `json:"url"`
+			URL   StandardField `json:"url"`
 			Roles struct {
 				Type            string        `json:"type"`
 				Description     string        `json:"description"`

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -6,6 +6,11 @@ import (
 	"os"
 )
 
+type StandardField struct {
+	Type        string `json:"type"`
+	Description string `json:"description"`
+	Format      string `json:"format,omitempty"`
+}
 type Schema struct {
 	Schema               string `json:"$schema"`
 	Title                string `json:"title"`
@@ -16,36 +21,13 @@ type Schema struct {
 			Type                 string `json:"type"`
 			AdditionalProperties bool   `json:"additionalProperties"`
 			Properties           struct {
-				Name struct {
-					Type        string `json:"type"`
-					Description string `json:"description"`
-				} `json:"name"`
-				Title struct {
-					Type        string `json:"type"`
-					Description string `json:"description"`
-				} `json:"title"`
-				Image struct {
-					Type        string `json:"type"`
-					Description string `json:"description"`
-				} `json:"image"`
-				Email struct {
-					Type        string `json:"type"`
-					Description string `json:"description"`
-					Format      string `json:"format"`
-				} `json:"email"`
-				Phone struct {
-					Type        string `json:"type"`
-					Description string `json:"description"`
-				} `json:"phone"`
-				Url struct {
-					Type        string `json:"type"`
-					Format      string `json:"format"`
-					Description string `json:"description"`
-				} `json:"url"`
-				Summary struct {
-					Type        string `json:"type"`
-					Description string `json:"description"`
-				} `json:"summary"`
+				Name            StandardField `json:"name"`
+				Title           StandardField `json:"title"`
+				Image           StandardField `json:"image"`
+				Email           StandardField `json:"email"`
+				Phone           StandardField `json:"phone"`
+				Url             StandardField `json:"url"`
+				Summary         StandardField `json:"summary"`
 				CurrentLocation struct {
 					Type        string `json:"type"`
 					Format      string `json:"format"`
@@ -81,19 +63,10 @@ type Schema struct {
 				Type                 string `json:"type"`
 				AdditionalProperties bool   `json:"additionalProperties"`
 				Properties           struct {
-					Name struct {
-						Type        string `json:"type"`
-						Description string `json:"description"`
-					} `json:"name"`
-					Description struct {
-						Type        string `json:"type"`
-						Description string `json:"description"`
-					} `json:"description"`
-					Position struct {
-						Type        string `json:"type"`
-						Description string `json:"description"`
-					} `json:"position"`
-					Location struct {
+					Name        StandardField `json:"name"`
+					Description StandardField `json:"description"`
+					Position    StandardField `json:"position"`
+					Location    struct {
 						Type        string `json:"type"`
 						Format      string `json:"format"`
 						Description string `json:"description"`
@@ -106,33 +79,15 @@ type Schema struct {
 							} `json:"long"`
 						} `json:"properties"`
 					} `json:"location"`
-					Url struct {
-						Type        string `json:"type"`
-						Description string `json:"description"`
-						Format      string `json:"format"`
-					} `json:"url"`
-					StartDate struct {
-						Type        string `json:"type"`
-						Description string `json:"description"`
-						Format      string `json:"format"`
-					} `json:"startDate"`
-					EndDate struct {
-						Type        string `json:"type"`
-						Description string `json:"description"`
-						Format      string `json:"format"`
-					} `json:"endDate"`
-					Summary struct {
-						Type        string `json:"type"`
-						Description string `json:"description"`
-					} `json:"summary"`
+					Url        StandardField `json:"url"`
+					StartDate  StandardField `json:"startDate"`
+					EndDate    StandardField `json:"endDate"`
+					Summary    StandardField `json:"summary"`
 					Highlights struct {
-						Type            string `json:"type"`
-						Description     string `json:"description"`
-						AdditionalItems bool   `json:"additionalItems"`
-						Items           struct {
-							Type        string `json:"type"`
-							Description string `json:"description"`
-						} `json:"items"`
+						Type            string        `json:"type"`
+						Description     string        `json:"description"`
+						AdditionalItems bool          `json:"additionalItems"`
+						Items           StandardField `json:"items"`
 					} `json:"highlights"`
 				} `json:"properties"`
 			} `json:"items"`
@@ -144,11 +99,8 @@ type Schema struct {
 				Type                 string `json:"type"`
 				AdditionalProperties bool   `json:"additionalProperties"`
 				Properties           struct {
-					Institution struct {
-						Type        string `json:"type"`
-						Description string `json:"description"`
-					} `json:"institution"`
-					Location struct {
+					Institution StandardField `json:"institution"`
+					Location    struct {
 						Type        string `json:"type"`
 						Format      string `json:"format"`
 						Description string `json:"description"`
@@ -161,55 +113,29 @@ type Schema struct {
 							} `json:"long"`
 						} `json:"properties"`
 					} `json:"location"`
-					Area struct {
-						Type        string `json:"type"`
-						Description string `json:"description"`
-					} `json:"area"`
-					StudyType struct {
-						Type        string `json:"type"`
-						Description string `json:"description"`
-					} `json:"studyType"`
-					StartDate struct {
-						Type        string `json:"type"`
-						Description string `json:"description"`
-						Format      string `json:"format"`
-					} `json:"startDate"`
-					EndDate struct {
-						Type        string `json:"type"`
-						Description string `json:"description"`
-						Format      string `json:"format"`
-					} `json:"endDate"`
-					Score struct {
+					Area      StandardField `json:"area"`
+					StudyType StandardField `json:"studyType"`
+					StartDate StandardField `json:"startDate"`
+					EndDate   StandardField `json:"endDate"`
+					Score     struct {
 						Type                 string `json:"type"`
 						AdditionalProperties bool   `json:"additionalProperties"`
 						Properties           struct {
-							Scoretype struct {
-								Type        string `json:"type"`
-								Description string `json:"description"`
-							} `json:"scoretype"`
-							Scorevalue struct {
-								Type        string `json:"type"`
-								Description string `json:"description"`
-							} `json:"scorevalue"`
+							Scoretype  StandardField `json:"scoretype"`
+							Scorevalue StandardField `json:"scorevalue"`
 						} `json:"properties"`
 					} `json:"score"`
 					Courses struct {
-						Type            string `json:"type"`
-						Description     string `json:"description"`
-						AdditionalItems bool   `json:"additionalItems"`
-						Items           struct {
-							Type        string `json:"type"`
-							Description string `json:"description"`
-						} `json:"items"`
+						Type            string        `json:"type"`
+						Description     string        `json:"description"`
+						AdditionalItems bool          `json:"additionalItems"`
+						Items           StandardField `json:"items"`
 					} `json:"courses"`
 					Honors struct {
-						Type            string `json:"type"`
-						Description     string `json:"description"`
-						AdditionalItems bool   `json:"additionalItems"`
-						Items           struct {
-							Type        string `json:"type"`
-							Description string `json:"description"`
-						} `json:"items"`
+						Type            string        `json:"type"`
+						Description     string        `json:"description"`
+						AdditionalItems bool          `json:"additionalItems"`
+						Items           StandardField `json:"items"`
 					} `json:"honors"`
 				} `json:"properties"`
 			} `json:"items"`
@@ -221,15 +147,9 @@ type Schema struct {
 				Type                 string `json:"type"`
 				AdditionalProperties bool   `json:"additionalProperties"`
 				Properties           struct {
-					Organization struct {
-						Type        string `json:"type"`
-						Description string `json:"description"`
-					} `json:"organization"`
-					Position struct {
-						Type        string `json:"type"`
-						Description string `json:"description"`
-					} `json:"position"`
-					Location struct {
+					Organization StandardField `json:"organization"`
+					Position     StandardField `json:"position"`
+					Location     struct {
 						Type        string `json:"type"`
 						Format      string `json:"format"`
 						Description string `json:"description"`
@@ -242,33 +162,15 @@ type Schema struct {
 							} `json:"long"`
 						} `json:"properties"`
 					} `json:"location"`
-					Url struct {
-						Type        string `json:"type"`
-						Description string `json:"description"`
-						Format      string `json:"format"`
-					} `json:"url"`
-					StartDate struct {
-						Type        string `json:"type"`
-						Description string `json:"description"`
-						Format      string `json:"format"`
-					} `json:"startDate"`
-					EndDate struct {
-						Type        string `json:"type"`
-						Description string `json:"description"`
-						Format      string `json:"format"`
-					} `json:"endDate"`
-					Summary struct {
-						Type        string `json:"type"`
-						Description string `json:"description"`
-					} `json:"summary"`
+					Url        StandardField `json:"url"`
+					StartDate  StandardField `json:"startDate"`
+					EndDate    StandardField `json:"endDate"`
+					Summary    StandardField `json:"summary"`
 					Highlights struct {
-						Type            string `json:"type"`
-						Description     string `json:"description"`
-						AdditionalItems bool   `json:"additionalItems"`
-						Items           struct {
-							Type        string `json:"type"`
-							Description string `json:"description"`
-						} `json:"items"`
+						Type            string        `json:"type"`
+						Description     string        `json:"description"`
+						AdditionalItems bool          `json:"additionalItems"`
+						Items           StandardField `json:"items"`
 					} `json:"highlights"`
 				} `json:"properties"`
 			} `json:"items"`
@@ -281,41 +183,18 @@ type Schema struct {
 				Type                 string `json:"type"`
 				AdditionalProperties bool   `json:"additionalProperties"`
 				Properties           struct {
-					Name struct {
-						Type        string `json:"type"`
-						Description string `json:"description"`
-					} `json:"name"`
-					Publisher struct {
-						Type        string `json:"type"`
-						Description string `json:"description"`
-					} `json:"publisher"`
-					ReleaseDate struct {
-						Type        string `json:"type"`
-						Description string `json:"description"`
-					} `json:"releaseDate"`
-					Resources struct {
-						Type            string `json:"type"`
-						Description     string `json:"description"`
-						AdditionalItems bool   `json:"additionalItems"`
-						Url             struct {
-							Type        string `json:"type"`
-							Format      string `json:"format"`
-							Description string `json:"description"`
-						} `json:"url"`
-						Label struct {
-							Type        string `json:"type"`
-							Description string `json:"description"`
-						} `json:"label"`
+					Name        StandardField `json:"name"`
+					Publisher   StandardField `json:"publisher"`
+					ReleaseDate StandardField `json:"releaseDate"`
+					Resources   struct {
+						Type            string        `json:"type"`
+						Description     string        `json:"description"`
+						AdditionalItems bool          `json:"additionalItems"`
+						Url             StandardField `json:"url"`
+						Label           StandardField `json:"label"`
 					} `json:"resources"`
-					Url struct {
-						Type        string `json:"type"`
-						Format      string `json:"format"`
-						Description string `json:"description"`
-					} `json:"url"`
-					Summary struct {
-						Type        string `json:"type"`
-						Description string `json:"description"`
-					} `json:"summary"`
+					Url     StandardField `json:"url"`
+					Summary StandardField `json:"summary"`
 				} `json:"properties"`
 			} `json:"items"`
 		} `json:"publications"`
@@ -327,51 +206,20 @@ type Schema struct {
 				Type                 string `json:"type"`
 				AdditionalProperties bool   `json:"additionalProperties"`
 				Properties           struct {
-					Name struct {
-						Type        string `json:"type"`
-						Description string `json:"description"`
-					} `json:"name"`
-					LegalType struct {
-						Type        string `json:"type"`
-						Description string `json:"description"`
-					} `json:"legalType"`
-					Description struct {
-						Type        string `json:"type"`
-						Description string `json:"description"`
-					} `json:"description"`
-					ApplicationDate struct {
-						Type        string `json:"type"`
-						Description string `json:"description"`
-						Format      string `json:"format"`
-					} `json:"applicationDate"`
-					GrantDate struct {
-						Type        string `json:"type"`
-						Description string `json:"description"`
-						Format      string `json:"format"`
-					} `json:"grantDate"`
-					EndDate struct {
-						Type        string `json:"type"`
-						Description string `json:"description"`
-						Format      string `json:"format"`
-					} `json:"endDate"`
-					Resources struct {
-						Type            string `json:"type"`
-						Description     string `json:"description"`
-						AdditionalItems bool   `json:"additionalItems"`
-						Url             struct {
-							Type        string `json:"type"`
-							Format      string `json:"format"`
-							Description string `json:"description"`
-						} `json:"url"`
-						Label struct {
-							Type        string `json:"type"`
-							Description string `json:"description"`
-						} `json:"label"`
+					Name            StandardField `json:"name"`
+					LegalType       StandardField `json:"legalType"`
+					Description     StandardField `json:"description"`
+					ApplicationDate StandardField `json:"applicationDate"`
+					GrantDate       StandardField `json:"grantDate"`
+					EndDate         StandardField `json:"endDate"`
+					Resources       struct {
+						Type            string        `json:"type"`
+						Description     string        `json:"description"`
+						AdditionalItems bool          `json:"additionalItems"`
+						Url             StandardField `json:"url"`
+						Label           StandardField `json:"label"`
 					} `json:"resources"`
-					IdNumber struct {
-						Type        string `json:"type"`
-						Description string `json:"description"`
-					} `json:"idNumber"`
+					IdNumber StandardField `json:"idNumber"`
 				} `json:"properties"`
 			} `json:"items"`
 		} `json:"legal"`
@@ -383,10 +231,7 @@ type Schema struct {
 				Type                 string `json:"type"`
 				AdditionalProperties bool   `json:"additionalProperties"`
 				Properties           struct {
-					Name struct {
-						Type        string `json:"type"`
-						Description string `json:"description"`
-					} `json:"name"`
+					Name    StandardField `json:"name"`
 					Keyword struct {
 						Type            string `json:"type"`
 						Description     string `json:"description"`
@@ -395,14 +240,8 @@ type Schema struct {
 							Type                 string `json:"type"`
 							AdditionalProperties bool   `json:"additionalProperties"`
 							Properties           struct {
-								Name struct {
-									Type        string `json:"type"`
-									Description string `json:"description"`
-								} `json:"name"`
-								Score struct {
-									Type        string `json:"type"`
-									Description string `json:"description"`
-								} `json:"score"`
+								Name  StandardField `json:"name"`
+								Score StandardField `json:"score"`
 							} `json:"properties"`
 						} `json:"items"`
 					} `json:"keyword"`
@@ -417,23 +256,10 @@ type Schema struct {
 				Type                 string `json:"type"`
 				AdditionalProperties bool   `json:"additionalProperties"`
 				Properties           struct {
-					Title struct {
-						Type        string `json:"type"`
-						Description string `json:"description"`
-					} `json:"title"`
-					Date struct {
-						Type        string `json:"type"`
-						Description string `json:"description"`
-						Format      string `json:"format"`
-					} `json:"date"`
-					Awarder struct {
-						Type        string `json:"type"`
-						Description string `json:"description"`
-					} `json:"awarder"`
-					Summary struct {
-						Type        string `json:"type"`
-						Description string `json:"description"`
-					} `json:"summary"`
+					Title   StandardField `json:"title"`
+					Date    StandardField `json:"date"`
+					Awarder StandardField `json:"awarder"`
+					Summary StandardField `json:"summary"`
 				} `json:"properties"`
 			} `json:"items"`
 		} `json:"awards"`
@@ -445,10 +271,7 @@ type Schema struct {
 				Type                 string `json:"type"`
 				AdditionalProperties bool   `json:"additionalProperties"`
 				Properties           struct {
-					Name struct {
-						Type        string `json:"type"`
-						Description string `json:"description"`
-					} `json:"name"`
+					Name     StandardField `json:"name"`
 					Location struct {
 						Type        string `json:"type"`
 						Format      string `json:"format"`
@@ -462,74 +285,37 @@ type Schema struct {
 							} `json:"long"`
 						} `json:"properties"`
 					} `json:"location"`
-					Description struct {
-						Type        string `json:"type"`
-						Description string `json:"description"`
-					} `json:"description"`
-					Highlights struct {
-						Type            string `json:"type"`
-						Description     string `json:"description"`
-						AdditionalItems bool   `json:"additionalItems"`
-						Items           struct {
-							Type        string `json:"type"`
-							Description string `json:"description"`
-						} `json:"items"`
+					Description StandardField `json:"description"`
+					Highlights  struct {
+						Type            string        `json:"type"`
+						Description     string        `json:"description"`
+						AdditionalItems bool          `json:"additionalItems"`
+						Items           StandardField `json:"items"`
 					} `json:"highlights"`
 					Keywords struct {
-						Type            string `json:"type"`
-						Description     string `json:"description"`
-						AdditionalItems bool   `json:"additionalItems"`
-						Items           struct {
-							Type        string `json:"type"`
-							Description string `json:"description"`
-						} `json:"items"`
+						Type            string        `json:"type"`
+						Description     string        `json:"description"`
+						AdditionalItems bool          `json:"additionalItems"`
+						Items           StandardField `json:"items"`
 					} `json:"keywords"`
-					StartDate struct {
-						Type        string `json:"type"`
-						Description string `json:"description"`
-						Format      string `json:"format"`
-					} `json:"startDate"`
-					EndDate struct {
-						Type        string `json:"type"`
-						Description string `json:"description"`
-						Format      string `json:"format"`
-					} `json:"endDate"`
+					StartDate StandardField `json:"startDate"`
+					EndDate   StandardField `json:"endDate"`
 					Resources struct {
-						Type            string `json:"type"`
-						Description     string `json:"description"`
-						AdditionalItems bool   `json:"additionalItems"`
-						Url             struct {
-							Type        string `json:"type"`
-							Format      string `json:"format"`
-							Description string `json:"description"`
-						} `json:"url"`
-						Label struct {
-							Type        string `json:"type"`
-							Description string `json:"description"`
-						} `json:"label"`
+						Type            string        `json:"type"`
+						Description     string        `json:"description"`
+						AdditionalItems bool          `json:"additionalItems"`
+						Url             StandardField `json:"url"`
+						Label           StandardField `json:"label"`
 					} `json:"resources"`
-					Url struct {
-						Type        string `json:"type"`
-						Format      string `json:"format"`
-						Description string `json:"description"`
-					} `json:"url"`
+					Url   StandardField `json:"url"`
 					Roles struct {
-						Type            string `json:"type"`
-						Description     string `json:"description"`
-						AdditionalItems bool   `json:"additionalItems"`
-						Items           struct {
-							Type        string `json:"type"`
-							Description string `json:"description"`
-						} `json:"items"`
+						Type            string        `json:"type"`
+						Description     string        `json:"description"`
+						AdditionalItems bool          `json:"additionalItems"`
+						Items           StandardField `json:"items"`
 					} `json:"roles"`
-					Entity struct {
-						Type        string `json:"type"`
-						Description string `json:"description"`
-					} `json:"entity"`
-					Type struct {
-						Type        string `json:"type"`
-						Description string `json:"description"`
-					} `json:"type"`
+					Entity StandardField `json:"entity"`
+					Type   StandardField `json:"type"`
 				} `json:"properties"`
 			} `json:"items"`
 		} `json:"projects"`
@@ -540,38 +326,13 @@ type Schema struct {
 				Type                 string `json:"type"`
 				AdditionalProperties bool   `json:"additionalProperties"`
 				Properties           struct {
-					Code struct {
-						Type        string `json:"type"`
-						Description string `json:"description"`
-					} `json:"code"`
-					Name struct {
-						Type        string `json:"type"`
-						Description string `json:"description"`
-					} `json:"name"`
-					Website struct {
-						Type        string `json:"type"`
-						Description string `json:"description"`
-						Format      string `json:"format"`
-					} `json:"website"`
-					Verification struct {
-						Type        string `json:"type"`
-						Description string `json:"description"`
-						Format      string `json:"format"`
-					} `json:"verification"`
-					GrantDate struct {
-						Type        string `json:"type"`
-						Description string `json:"description"`
-						Format      string `json:"format"`
-					} `json:"grantDate"`
-					Score struct {
-						Type        string `json:"type"`
-						Description string `json:"description"`
-					} `json:"score"`
-					EndDate struct {
-						Type        string `json:"type"`
-						Description string `json:"description"`
-						Format      string `json:"format"`
-					} `json:"endDate"`
+					Code          StandardField `json:"code"`
+					Name          StandardField `json:"name"`
+					Website       StandardField `json:"website"`
+					Verification  StandardField `json:"verification"`
+					GrantDate     StandardField `json:"grantDate"`
+					Score         StandardField `json:"score"`
+					EndDate       StandardField `json:"endDate"`
 					DoesNotExpire struct {
 						Type   string `json:"type"`
 						Format string `json:"format"`
@@ -587,22 +348,10 @@ type Schema struct {
 				Type                 string `json:"type"`
 				AdditionalProperties bool   `json:"additionalProperties"`
 				Properties           struct {
-					Name struct {
-						Type        string `json:"type"`
-						Description string `json:"description"`
-					} `json:"name"`
-					Company struct {
-						Type        string `json:"type"`
-						Description string `json:"description"`
-					} `json:"company"`
-					Position struct {
-						Type        string `json:"type"`
-						Description string `json:"description"`
-					} `json:"position"`
-					Reference struct {
-						Type        string `json:"type"`
-						Description string `json:"description"`
-					} `json:"reference"`
+					Name      StandardField `json:"name"`
+					Company   StandardField `json:"company"`
+					Position  StandardField `json:"position"`
+					Reference StandardField `json:"reference"`
 				} `json:"properties"`
 			} `json:"items"`
 		} `json:"references"`
@@ -614,14 +363,8 @@ type Schema struct {
 				Type                 string `json:"type"`
 				AdditionalProperties bool   `json:"additionalProperties"`
 				Properties           struct {
-					Language struct {
-						Type        string `json:"type"`
-						Description string `json:"description"`
-					} `json:"language"`
-					Score struct {
-						Type        string `json:"type"`
-						Description string `json:"description"`
-					} `json:"score"`
+					Language StandardField `json:"language"`
+					Score    StandardField `json:"score"`
 				} `json:"properties"`
 			} `json:"items"`
 		} `json:"languages"`
@@ -632,18 +375,12 @@ type Schema struct {
 				Type                 string `json:"type"`
 				AdditionalProperties bool   `json:"additionalProperties"`
 				Properties           struct {
-					Name struct {
-						Type        string `json:"type"`
-						Description string `json:"description"`
-					} `json:"name"`
+					Name     StandardField `json:"name"`
 					Keywords struct {
-						Type            string `json:"type"`
-						Description     string `json:"description"`
-						AdditionalItems bool   `json:"additionalItems"`
-						Items           struct {
-							Type        string `json:"type"`
-							Description string `json:"description"`
-						} `json:"items"`
+						Type            string        `json:"type"`
+						Description     string        `json:"description"`
+						AdditionalItems bool          `json:"additionalItems"`
+						Items           StandardField `json:"items"`
 					} `json:"keywords"`
 				} `json:"properties"`
 			} `json:"items"`
@@ -653,19 +390,9 @@ type Schema struct {
 			Description          string `json:"description"`
 			AdditionalProperties bool   `json:"additionalProperties"`
 			Properties           struct {
-				Canonical struct {
-					Type        string `json:"type"`
-					Description string `json:"description"`
-				} `json:"canonical"`
-				Version struct {
-					Type        string `json:"type"`
-					Description string `json:"description"`
-				} `json:"version"`
-				LastModified struct {
-					Type        string `json:"type"`
-					Description string `json:"description"`
-					Format      string `json:"format"`
-				} `json:"lastModified"`
+				Canonical    StandardField `json:"canonical"`
+				Version      StandardField `json:"version"`
+				LastModified StandardField `json:"lastModified"`
 			} `json:"properties"`
 		} `json:"meta"`
 	} `json:"properties"`

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -7,673 +7,672 @@ import (
 )
 
 type Schema struct {
-	Schema               string
-	Title                string
-	Type                 string
-	AdditionalProperties bool
+	Schema               string `json:"$schema"`
+	Title                string `json:"title"`
+	Type                 string `json:"type"`
+	AdditionalProperties bool   `json:"additionalProperties"`
 	Properties           struct {
 		Core struct {
-			Type                 string
-			AdditionalProperties bool
+			Type                 string `json:"type"`
+			AdditionalProperties bool   `json:"additionalProperties"`
 			Properties           struct {
 				Name struct {
-					Type        string
-					Description string
-				}
+					Type        string `json:"type"`
+					Description string `json:"description"`
+				} `json:"name"`
 				Title struct {
-					Type        string
-					Description string
-				}
+					Type        string `json:"type"`
+					Description string `json:"description"`
+				} `json:"title"`
 				Image struct {
-					Type        string
-					Description string
-				}
+					Type        string `json:"type"`
+					Description string `json:"description"`
+				} `json:"image"`
 				Email struct {
-					Type        string
-					Description string
-					Format      string
-				}
+					Type        string `json:"type"`
+					Description string `json:"description"`
+					Format      string `json:"format"`
+				} `json:"email"`
 				Phone struct {
-					Type        string
-					Description string
-				}
-				URL struct {
-					Type        string
-					Format      string
-					Description string
-				}
+					Type        string `json:"type"`
+					Description string `json:"description"`
+				} `json:"phone"`
+				Url struct {
+					Type        string `json:"type"`
+					Format      string `json:"format"`
+					Description string `json:"description"`
+				} `json:"url"`
 				Summary struct {
-					Type        string
-					Format      string
-					Description string
-				}
+					Type        string `json:"type"`
+					Description string `json:"description"`
+				} `json:"summary"`
 				CurrentLocation struct {
-					Type        string
-					Format      string
-					Description string
+					Type        string `json:"type"`
+					Format      string `json:"format"`
+					Description string `json:"description"`
 					Properties  struct {
 						Lat struct {
-							Type string
-						}
+							Type string `json:"type"`
+						} `json:"lat"`
 						Long struct {
-							Type string
-						}
-					}
-				}
+							Type string `json:"type"`
+						} `json:"long"`
+					} `json:"properties"`
+				} `json:"currentLocation"`
 				PermanentLocation struct {
-					Type        string
-					Format      string
-					Description string
+					Type        string `json:"type"`
+					Format      string `json:"format"`
+					Description string `json:"description"`
 					Properties  struct {
 						Lat struct {
-							Type string
-						}
+							Type string `json:"type"`
+						} `json:"lat"`
 						Long struct {
-							Type string
-						}
-					}
-				}
-			}
-		}
+							Type string `json:"type"`
+						} `json:"long"`
+					} `json:"properties"`
+				} `json:"permanentLocation"`
+			} `json:"properties"`
+		} `json:"core"`
 		Work struct {
-			Type            string
-			AdditionalItems bool
+			Type            string `json:"type"`
+			AdditionalItems bool   `json:"additionalItems"`
 			Items           struct {
-				Type                 string
-				AdditionalProperties bool
+				Type                 string `json:"type"`
+				AdditionalProperties bool   `json:"additionalProperties"`
 				Properties           struct {
 					Name struct {
-						Type        string
-						Description string
-					}
+						Type        string `json:"type"`
+						Description string `json:"description"`
+					} `json:"name"`
 					Description struct {
-						Type        string
-						Description string
-					}
+						Type        string `json:"type"`
+						Description string `json:"description"`
+					} `json:"description"`
 					Position struct {
-						Type        string
-						Description string
-					}
+						Type        string `json:"type"`
+						Description string `json:"description"`
+					} `json:"position"`
 					Location struct {
-						Type        string
-						Format      string
-						Description string
+						Type        string `json:"type"`
+						Format      string `json:"format"`
+						Description string `json:"description"`
 						Properties  struct {
 							Lat struct {
-								Type string
-							}
+								Type string `json:"type"`
+							} `json:"lat"`
 							Long struct {
-								Type string
-							}
-						}
-					}
-					URL struct {
-						Type        string
-						Description string
-						Format      string
-					}
+								Type string `json:"type"`
+							} `json:"long"`
+						} `json:"properties"`
+					} `json:"location"`
+					Url struct {
+						Type        string `json:"type"`
+						Description string `json:"description"`
+						Format      string `json:"format"`
+					} `json:"url"`
 					StartDate struct {
-						Type        string
-						Description string
-						Format      string
-					}
+						Type        string `json:"type"`
+						Description string `json:"description"`
+						Format      string `json:"format"`
+					} `json:"startDate"`
 					EndDate struct {
-						Type        string
-						Description string
-						Format      string
-					}
+						Type        string `json:"type"`
+						Description string `json:"description"`
+						Format      string `json:"format"`
+					} `json:"endDate"`
 					Summary struct {
-						Type        string
-						Description string
-					}
+						Type        string `json:"type"`
+						Description string `json:"description"`
+					} `json:"summary"`
 					Highlights struct {
-						Type            string
-						Description     string
-						AdditionalItems bool
+						Type            string `json:"type"`
+						Description     string `json:"description"`
+						AdditionalItems bool   `json:"additionalItems"`
 						Items           struct {
-							Type        string
-							Description string
-						}
-					}
-				}
-			}
-		}
+							Type        string `json:"type"`
+							Description string `json:"description"`
+						} `json:"items"`
+					} `json:"highlights"`
+				} `json:"properties"`
+			} `json:"items"`
+		} `json:"work"`
 		Education struct {
-			Type            string
-			AdditionalItems bool
+			Type            string `json:"type"`
+			AdditionalItems bool   `json:"additionalItems"`
 			Items           struct {
-				Type                 string
-				AdditionalProperties bool
+				Type                 string `json:"type"`
+				AdditionalProperties bool   `json:"additionalProperties"`
 				Properties           struct {
 					Institution struct {
-						Type        string
-						Description string
-					}
+						Type        string `json:"type"`
+						Description string `json:"description"`
+					} `json:"institution"`
 					Location struct {
-						Type        string
-						Format      string
-						Description string
+						Type        string `json:"type"`
+						Format      string `json:"format"`
+						Description string `json:"description"`
 						Properties  struct {
 							Lat struct {
-								Type string
-							}
+								Type string `json:"type"`
+							} `json:"lat"`
 							Long struct {
-								Type string
-							}
-						}
-					}
+								Type string `json:"type"`
+							} `json:"long"`
+						} `json:"properties"`
+					} `json:"location"`
 					Area struct {
-						Type        string
-						Description string
-					}
+						Type        string `json:"type"`
+						Description string `json:"description"`
+					} `json:"area"`
 					StudyType struct {
-						Type        string
-						Description string
-					}
+						Type        string `json:"type"`
+						Description string `json:"description"`
+					} `json:"studyType"`
 					StartDate struct {
-						Type        string
-						Description string
-						Format      string
-					}
+						Type        string `json:"type"`
+						Description string `json:"description"`
+						Format      string `json:"format"`
+					} `json:"startDate"`
 					EndDate struct {
-						Type        string
-						Description string
-						Format      string
-					}
+						Type        string `json:"type"`
+						Description string `json:"description"`
+						Format      string `json:"format"`
+					} `json:"endDate"`
 					Score struct {
-						Type                 string
-						AdditionalProperties bool
+						Type                 string `json:"type"`
+						AdditionalProperties bool   `json:"additionalProperties"`
 						Properties           struct {
 							Scoretype struct {
-								Type        string
-								Description string
-							}
+								Type        string `json:"type"`
+								Description string `json:"description"`
+							} `json:"scoretype"`
 							Scorevalue struct {
-								Type        string
-								Description string
-							}
-						}
-					}
+								Type        string `json:"type"`
+								Description string `json:"description"`
+							} `json:"scorevalue"`
+						} `json:"properties"`
+					} `json:"score"`
 					Courses struct {
-						Type            string
-						Description     string
-						AdditionalItems bool
+						Type            string `json:"type"`
+						Description     string `json:"description"`
+						AdditionalItems bool   `json:"additionalItems"`
 						Items           struct {
-							Type        string
-							Description string
-						}
-					}
+							Type        string `json:"type"`
+							Description string `json:"description"`
+						} `json:"items"`
+					} `json:"courses"`
 					Honors struct {
-						Type            string
-						Description     string
-						AdditionalItems bool
+						Type            string `json:"type"`
+						Description     string `json:"description"`
+						AdditionalItems bool   `json:"additionalItems"`
 						Items           struct {
-							Type        string
-							Description string
-						}
-					}
-				}
-			}
-		}
+							Type        string `json:"type"`
+							Description string `json:"description"`
+						} `json:"items"`
+					} `json:"honors"`
+				} `json:"properties"`
+			} `json:"items"`
+		} `json:"education"`
 		Volunteer struct {
-			Type            string
-			AdditionalItems bool
+			Type            string `json:"type"`
+			AdditionalItems bool   `json:"additionalItems"`
 			Items           struct {
-				Type                 string
-				AdditionalProperties bool
+				Type                 string `json:"type"`
+				AdditionalProperties bool   `json:"additionalProperties"`
 				Properties           struct {
 					Organization struct {
-						Type        string
-						Description string
-					}
+						Type        string `json:"type"`
+						Description string `json:"description"`
+					} `json:"organization"`
 					Position struct {
-						Type        string
-						Description string
-					}
+						Type        string `json:"type"`
+						Description string `json:"description"`
+					} `json:"position"`
 					Location struct {
-						Type        string
-						Format      string
-						Description string
+						Type        string `json:"type"`
+						Format      string `json:"format"`
+						Description string `json:"description"`
 						Properties  struct {
 							Lat struct {
-								Type string
-							}
+								Type string `json:"type"`
+							} `json:"lat"`
 							Long struct {
-								Type string
-							}
-						}
-					}
-					URL struct {
-						Type        string
-						Description string
-						Format      string
-					}
+								Type string `json:"type"`
+							} `json:"long"`
+						} `json:"properties"`
+					} `json:"location"`
+					Url struct {
+						Type        string `json:"type"`
+						Description string `json:"description"`
+						Format      string `json:"format"`
+					} `json:"url"`
 					StartDate struct {
-						Type        string
-						Description string
-						Format      string
-					}
+						Type        string `json:"type"`
+						Description string `json:"description"`
+						Format      string `json:"format"`
+					} `json:"startDate"`
 					EndDate struct {
-						Type        string
-						Description string
-						Format      string
-					}
+						Type        string `json:"type"`
+						Description string `json:"description"`
+						Format      string `json:"format"`
+					} `json:"endDate"`
 					Summary struct {
-						Type        string
-						Description string
-					}
+						Type        string `json:"type"`
+						Description string `json:"description"`
+					} `json:"summary"`
 					Highlights struct {
-						Type            string
-						Description     string
-						AdditionalItems bool
+						Type            string `json:"type"`
+						Description     string `json:"description"`
+						AdditionalItems bool   `json:"additionalItems"`
 						Items           struct {
-							Type        string
-							Description string
-						}
-					}
-				}
-			}
-		}
+							Type        string `json:"type"`
+							Description string `json:"description"`
+						} `json:"items"`
+					} `json:"highlights"`
+				} `json:"properties"`
+			} `json:"items"`
+		} `json:"volunteer"`
 		Publications struct {
-			Type            string
-			Description     string
-			AdditionalItems bool
+			Type            string `json:"type"`
+			Description     string `json:"description"`
+			AdditionalItems bool   `json:"additionalItems"`
 			Items           struct {
-				Type                 string
-				AdditionalProperties bool
+				Type                 string `json:"type"`
+				AdditionalProperties bool   `json:"additionalProperties"`
 				Properties           struct {
 					Name struct {
-						Type        string
-						Description string
-					}
+						Type        string `json:"type"`
+						Description string `json:"description"`
+					} `json:"name"`
 					Publisher struct {
-						Type        string
-						Description string
-					}
+						Type        string `json:"type"`
+						Description string `json:"description"`
+					} `json:"publisher"`
 					ReleaseDate struct {
-						Type        string
-						Description string
-					}
+						Type        string `json:"type"`
+						Description string `json:"description"`
+					} `json:"releaseDate"`
 					Resources struct {
-						Type            string
-						Description     string
-						AdditionalItems bool
-						URL             struct {
-							Type        string
-							Format      string
-							Description string
-						}
+						Type            string `json:"type"`
+						Description     string `json:"description"`
+						AdditionalItems bool   `json:"additionalItems"`
+						Url             struct {
+							Type        string `json:"type"`
+							Format      string `json:"format"`
+							Description string `json:"description"`
+						} `json:"url"`
 						Label struct {
-							Type        string
-							Description string
-						}
-					}
-					URL struct {
-						Type        string
-						Format      string
-						Description string
-					}
+							Type        string `json:"type"`
+							Description string `json:"description"`
+						} `json:"label"`
+					} `json:"resources"`
+					Url struct {
+						Type        string `json:"type"`
+						Format      string `json:"format"`
+						Description string `json:"description"`
+					} `json:"url"`
 					Summary struct {
-						Type        string
-						Description string
-					}
-				}
-			}
-		}
+						Type        string `json:"type"`
+						Description string `json:"description"`
+					} `json:"summary"`
+				} `json:"properties"`
+			} `json:"items"`
+		} `json:"publications"`
 		Legal struct {
-			Type            string
-			Description     string
-			AdditionalItems bool
+			Type            string `json:"type"`
+			Description     string `json:"description"`
+			AdditionalItems bool   `json:"additionalItems"`
 			Items           struct {
-				Type                 string
-				AdditionalProperties bool
+				Type                 string `json:"type"`
+				AdditionalProperties bool   `json:"additionalProperties"`
 				Properties           struct {
 					Name struct {
-						Type        string
-						Description string
-					}
+						Type        string `json:"type"`
+						Description string `json:"description"`
+					} `json:"name"`
 					LegalType struct {
-						Type        string
-						Description string
-					}
+						Type        string `json:"type"`
+						Description string `json:"description"`
+					} `json:"legalType"`
 					Description struct {
-						Type        string
-						Description string
-					}
+						Type        string `json:"type"`
+						Description string `json:"description"`
+					} `json:"description"`
 					ApplicationDate struct {
-						Type        string
-						Description string
-						Format      string
-					}
+						Type        string `json:"type"`
+						Description string `json:"description"`
+						Format      string `json:"format"`
+					} `json:"applicationDate"`
 					GrantDate struct {
-						Type        string
-						Description string
-						Format      string
-					}
+						Type        string `json:"type"`
+						Description string `json:"description"`
+						Format      string `json:"format"`
+					} `json:"grantDate"`
 					EndDate struct {
-						Type        string
-						Description string
-						Format      string
-					}
+						Type        string `json:"type"`
+						Description string `json:"description"`
+						Format      string `json:"format"`
+					} `json:"endDate"`
 					Resources struct {
-						Type            string
-						Description     string
-						AdditionalItems bool
-						URL             struct {
-							Type        string
-							Format      string
-							Description string
-						}
+						Type            string `json:"type"`
+						Description     string `json:"description"`
+						AdditionalItems bool   `json:"additionalItems"`
+						Url             struct {
+							Type        string `json:"type"`
+							Format      string `json:"format"`
+							Description string `json:"description"`
+						} `json:"url"`
 						Label struct {
-							Type        string
-							Description string
-						}
-					}
-					IDNumber struct {
-						Type        string
-						Description string
-					}
-				}
-			}
-		}
+							Type        string `json:"type"`
+							Description string `json:"description"`
+						} `json:"label"`
+					} `json:"resources"`
+					IdNumber struct {
+						Type        string `json:"type"`
+						Description string `json:"description"`
+					} `json:"idNumber"`
+				} `json:"properties"`
+			} `json:"items"`
+		} `json:"legal"`
 		Skills struct {
-			Type            string
-			Description     string
-			AdditionalItems bool
+			Type            string `json:"type"`
+			Description     string `json:"description"`
+			AdditionalItems bool   `json:"additionalItems"`
 			Items           struct {
-				Type                 string
-				AdditionalProperties bool
+				Type                 string `json:"type"`
+				AdditionalProperties bool   `json:"additionalProperties"`
 				Properties           struct {
 					Name struct {
-						Type        string
-						Description string
-					}
+						Type        string `json:"type"`
+						Description string `json:"description"`
+					} `json:"name"`
 					Keyword struct {
-						Type            string
-						Description     string
-						AdditionalItems bool
+						Type            string `json:"type"`
+						Description     string `json:"description"`
+						AdditionalItems bool   `json:"additionalItems"`
 						Items           struct {
-							Type                 string
-							AdditionalProperties bool
+							Type                 string `json:"type"`
+							AdditionalProperties bool   `json:"additionalProperties"`
 							Properties           struct {
 								Name struct {
-									Type        string
-									Description string
-								}
+									Type        string `json:"type"`
+									Description string `json:"description"`
+								} `json:"name"`
 								Score struct {
-									Type        string
-									Description string
-								}
-							}
-						}
-					}
-				}
-			}
-		}
+									Type        string `json:"type"`
+									Description string `json:"description"`
+								} `json:"score"`
+							} `json:"properties"`
+						} `json:"items"`
+					} `json:"keyword"`
+				} `json:"properties"`
+			} `json:"items"`
+		} `json:"skills"`
 		Awards struct {
-			Type            string
-			Description     string
-			AdditionalItems bool
+			Type            string `json:"type"`
+			Description     string `json:"description"`
+			AdditionalItems bool   `json:"additionalItems"`
 			Items           struct {
-				Type                 string
-				AdditionalProperties bool
+				Type                 string `json:"type"`
+				AdditionalProperties bool   `json:"additionalProperties"`
 				Properties           struct {
 					Title struct {
-						Type        string
-						Description string
-					}
+						Type        string `json:"type"`
+						Description string `json:"description"`
+					} `json:"title"`
 					Date struct {
-						Type        string
-						Description string
-						Format      string
-					}
+						Type        string `json:"type"`
+						Description string `json:"description"`
+						Format      string `json:"format"`
+					} `json:"date"`
 					Awarder struct {
-						Type        string
-						Description string
-					}
+						Type        string `json:"type"`
+						Description string `json:"description"`
+					} `json:"awarder"`
 					Summary struct {
-						Type        string
-						Description string
-					}
-				}
-			}
-		}
+						Type        string `json:"type"`
+						Description string `json:"description"`
+					} `json:"summary"`
+				} `json:"properties"`
+			} `json:"items"`
+		} `json:"awards"`
 		Projects struct {
-			Type            string
-			Description     string
-			AdditionalItems bool
+			Type            string `json:"type"`
+			Description     string `json:"description"`
+			AdditionalItems bool   `json:"additionalItems"`
 			Items           struct {
-				Type                 string
-				AdditionalProperties bool
+				Type                 string `json:"type"`
+				AdditionalProperties bool   `json:"additionalProperties"`
 				Properties           struct {
 					Name struct {
-						Type        string
-						Description string
-					}
+						Type        string `json:"type"`
+						Description string `json:"description"`
+					} `json:"name"`
 					Location struct {
-						Type        string
-						Format      string
-						Description string
+						Type        string `json:"type"`
+						Format      string `json:"format"`
+						Description string `json:"description"`
 						Properties  struct {
 							Lat struct {
-								Type string
-							}
+								Type string `json:"type"`
+							} `json:"lat"`
 							Long struct {
-								Type string
-							}
-						}
-					}
+								Type string `json:"type"`
+							} `json:"long"`
+						} `json:"properties"`
+					} `json:"location"`
 					Description struct {
-						Type        string
-						Description string
-					}
+						Type        string `json:"type"`
+						Description string `json:"description"`
+					} `json:"description"`
 					Highlights struct {
-						Type            string
-						Description     string
-						AdditionalItems bool
+						Type            string `json:"type"`
+						Description     string `json:"description"`
+						AdditionalItems bool   `json:"additionalItems"`
 						Items           struct {
-							Type        string
-							Description string
-						}
-					}
+							Type        string `json:"type"`
+							Description string `json:"description"`
+						} `json:"items"`
+					} `json:"highlights"`
 					Keywords struct {
-						Type            string
-						Description     string
-						AdditionalItems bool
+						Type            string `json:"type"`
+						Description     string `json:"description"`
+						AdditionalItems bool   `json:"additionalItems"`
 						Items           struct {
-							Type        string
-							Description string
-						}
-					}
+							Type        string `json:"type"`
+							Description string `json:"description"`
+						} `json:"items"`
+					} `json:"keywords"`
 					StartDate struct {
-						Type        string
-						Description string
-						Format      string
-					}
+						Type        string `json:"type"`
+						Description string `json:"description"`
+						Format      string `json:"format"`
+					} `json:"startDate"`
 					EndDate struct {
-						Type        string
-						Description string
-						Format      string
-					}
+						Type        string `json:"type"`
+						Description string `json:"description"`
+						Format      string `json:"format"`
+					} `json:"endDate"`
 					Resources struct {
-						Type            string
-						Description     string
-						AdditionalItems bool
-						URL             struct {
-							Type        string
-							Format      string
-							Description string
-						}
+						Type            string `json:"type"`
+						Description     string `json:"description"`
+						AdditionalItems bool   `json:"additionalItems"`
+						Url             struct {
+							Type        string `json:"type"`
+							Format      string `json:"format"`
+							Description string `json:"description"`
+						} `json:"url"`
 						Label struct {
-							Type        string
-							Description string
-						}
-					}
-					URL struct {
-						Type        string
-						Format      string
-						Description string
-					}
+							Type        string `json:"type"`
+							Description string `json:"description"`
+						} `json:"label"`
+					} `json:"resources"`
+					Url struct {
+						Type        string `json:"type"`
+						Format      string `json:"format"`
+						Description string `json:"description"`
+					} `json:"url"`
 					Roles struct {
-						Type            string
-						Description     string
-						AdditionalItems bool
+						Type            string `json:"type"`
+						Description     string `json:"description"`
+						AdditionalItems bool   `json:"additionalItems"`
 						Items           struct {
-							Type        string
-							Description string
-						}
-					}
+							Type        string `json:"type"`
+							Description string `json:"description"`
+						} `json:"items"`
+					} `json:"roles"`
 					Entity struct {
-						Type        string
-						Description string
-					}
+						Type        string `json:"type"`
+						Description string `json:"description"`
+					} `json:"entity"`
 					Type struct {
-						Type        string
-						Description string
-					}
-				}
-			}
-		}
+						Type        string `json:"type"`
+						Description string `json:"description"`
+					} `json:"type"`
+				} `json:"properties"`
+			} `json:"items"`
+		} `json:"projects"`
 		Certificates struct {
-			Type            string
-			AdditionalItems bool
+			Type            string `json:"type"`
+			AdditionalItems bool   `json:"additionalItems"`
 			Items           struct {
-				Type                 string
-				AdditionalProperties bool
+				Type                 string `json:"type"`
+				AdditionalProperties bool   `json:"additionalProperties"`
 				Properties           struct {
 					Code struct {
-						Type        string
-						Description string
-					}
+						Type        string `json:"type"`
+						Description string `json:"description"`
+					} `json:"code"`
 					Name struct {
-						Type        string
-						Description string
-					}
+						Type        string `json:"type"`
+						Description string `json:"description"`
+					} `json:"name"`
 					Website struct {
-						Type        string
-						Description string
-						Format      string
-					}
+						Type        string `json:"type"`
+						Description string `json:"description"`
+						Format      string `json:"format"`
+					} `json:"website"`
 					Verification struct {
-						Type        string
-						Description string
-						Format      string
-					}
+						Type        string `json:"type"`
+						Description string `json:"description"`
+						Format      string `json:"format"`
+					} `json:"verification"`
 					GrantDate struct {
-						Type        string
-						Description string
-						Format      string
-					}
+						Type        string `json:"type"`
+						Description string `json:"description"`
+						Format      string `json:"format"`
+					} `json:"grantDate"`
 					Score struct {
-						Type        string
-						Description string
-					}
+						Type        string `json:"type"`
+						Description string `json:"description"`
+					} `json:"score"`
 					EndDate struct {
-						Type        string
-						Description string
-						Format      string
-					}
+						Type        string `json:"type"`
+						Description string `json:"description"`
+						Format      string `json:"format"`
+					} `json:"endDate"`
 					DoesNotExpire struct {
-						Type   string
-						Format string
-					}
-				}
-			}
-		}
+						Type   string `json:"type"`
+						Format string `json:"format"`
+					} `json:"doesNotExpire"`
+				} `json:"properties"`
+			} `json:"items"`
+		} `json:"certificates"`
 		References struct {
-			Type            string
-			Description     string
-			AdditionalItems bool
+			Type            string `json:"type"`
+			Description     string `json:"description"`
+			AdditionalItems bool   `json:"additionalItems"`
 			Items           struct {
-				Type                 string
-				AdditionalProperties bool
+				Type                 string `json:"type"`
+				AdditionalProperties bool   `json:"additionalProperties"`
 				Properties           struct {
 					Name struct {
-						Type        string
-						Description string
-					}
+						Type        string `json:"type"`
+						Description string `json:"description"`
+					} `json:"name"`
 					Company struct {
-						Type        string
-						Description string
-					}
+						Type        string `json:"type"`
+						Description string `json:"description"`
+					} `json:"company"`
 					Position struct {
-						Type        string
-						Description string
-					}
+						Type        string `json:"type"`
+						Description string `json:"description"`
+					} `json:"position"`
 					Reference struct {
-						Type        string
-						Description string
-					}
-				}
-			}
-		}
+						Type        string `json:"type"`
+						Description string `json:"description"`
+					} `json:"reference"`
+				} `json:"properties"`
+			} `json:"items"`
+		} `json:"references"`
 		Languages struct {
-			Type            string
-			Description     string
-			AdditionalItems bool
+			Type            string `json:"type"`
+			Description     string `json:"description"`
+			AdditionalItems bool   `json:"additionalItems"`
 			Items           struct {
-				Type                 string
-				AdditionalProperties bool
+				Type                 string `json:"type"`
+				AdditionalProperties bool   `json:"additionalProperties"`
 				Properties           struct {
 					Language struct {
-						Type        string
-						Description string
-					}
+						Type        string `json:"type"`
+						Description string `json:"description"`
+					} `json:"language"`
 					Score struct {
-						Type        string
-						Description string
-					}
-				}
-			}
-		}
+						Type        string `json:"type"`
+						Description string `json:"description"`
+					} `json:"score"`
+				} `json:"properties"`
+			} `json:"items"`
+		} `json:"languages"`
 		Interests struct {
-			Type            string
-			Description     string
-			AdditionalItems bool
+			Type            string `json:"type"`
+			AdditionalItems bool   `json:"additionalItems"`
 			Items           struct {
-				Type                 string
-				AdditionalProperties bool
+				Type                 string `json:"type"`
+				AdditionalProperties bool   `json:"additionalProperties"`
 				Properties           struct {
 					Name struct {
-						Type        string
-						Description string
-					}
-				}
-				Keywords struct {
-					Type            string
-					Description     string
-					AdditionalItems bool
-					Items           struct {
-						Type        string
-						Description string
-					}
-				}
-			}
-		}
+						Type        string `json:"type"`
+						Description string `json:"description"`
+					} `json:"name"`
+					Keywords struct {
+						Type            string `json:"type"`
+						Description     string `json:"description"`
+						AdditionalItems bool   `json:"additionalItems"`
+						Items           struct {
+							Type        string `json:"type"`
+							Description string `json:"description"`
+						} `json:"items"`
+					} `json:"keywords"`
+				} `json:"properties"`
+			} `json:"items"`
+		} `json:"interests"`
 		Meta struct {
-			Type                 string
-			Description          string
-			AdditionalProperties bool
+			Type                 string `json:"type"`
+			Description          string `json:"description"`
+			AdditionalProperties bool   `json:"additionalProperties"`
 			Properties           struct {
 				Canonical struct {
-					Type        string
-					Description string
-				}
+					Type        string `json:"type"`
+					Description string `json:"description"`
+				} `json:"canonical"`
 				Version struct {
-					Type        string
-					Description string
-				}
+					Type        string `json:"type"`
+					Description string `json:"description"`
+				} `json:"version"`
 				LastModified struct {
-					Type        string
-					Description string
-					Format      string
-				}
-			}
-		}
-	}
+					Type        string `json:"type"`
+					Description string `json:"description"`
+					Format      string `json:"format"`
+				} `json:"lastModified"`
+			} `json:"properties"`
+		} `json:"meta"`
+	} `json:"properties"`
 }
 
-func GetDefaultSchema() (Schema, error) {
+// GetSchema fills the Schema{} struct with correct values and returns it
+func GetSchema() (Schema, error) {
 	valuesFile, err := os.Open("./schema.json")
 	if err != nil {
 		return Schema{}, err
@@ -687,8 +686,4 @@ func GetDefaultSchema() (Schema, error) {
 	schema := Schema{}
 	err = json.Unmarshal(values, &schema)
 	return schema, nil
-}
-
-func GetSchema() Schema {
-	return Schema{}
 }

--- a/schema/schema.json
+++ b/schema/schema.json
@@ -1,0 +1,664 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Resumic Schema",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "core": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "e.g. John Doe"
+        },
+        "title": {
+          "type": "string",
+          "description": "e.g. Software Engineer"
+        },
+        "image": {
+          "type": "string",
+          "description": "e.g. example.com/Abcxyz - [URL (as per RFC 3986) to a image in JPEG or PNG format]"
+        },
+        "email": {
+          "type": "string",
+          "description": "e.g. lucas@example.com",
+          "format": "email"
+        },
+        "phone": {
+          "type": "string",
+          "description": "e.g. 912-217-7923 - [Phone numbers are stored as strings so use any format you like]"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri",
+          "description": "e.g. http://www.example.com/my-slides/"
+        },
+        "summary": {
+          "type": "string",
+          "description": "Write a short 2-3 sentence biography about yourself"
+        },
+        "currentLocation": {
+          "type": "object",
+          "format": "location",
+          "description": "Select the location where you currently live.",
+          "properties": {
+            "lat": {
+              "type": "number"
+            },
+            "long": {
+              "type": "number"
+            }
+          }
+        },
+        "permanentLocation": {
+          "type": "object",
+          "format": "location",
+          "description": "Select the location where you permanently live.",
+          "properties": {
+            "lat": {
+              "type": "number"
+            },
+            "long": {
+              "type": "number"
+            }
+          }
+        }
+      }
+    },
+    "work": {
+      "type": "array",
+      "additionalItems": false,
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "e.g. XYZ Inc. - [Company name]"
+          },
+          "description": {
+            "type": "string",
+            "description": "e.g. A social media company - [Description of the companies primary activity]"
+          },
+          "position": {
+            "type": "string",
+            "description": "e.g. Software Engineer - [Position at the company]"
+          },
+          "location": {
+            "type": "object",
+            "format": "location",
+            "description": "e.g. Germany - [Location for this activity]",
+            "properties": {
+              "lat": {
+                "type": "number"
+              },
+              "long": {
+                "type": "number"
+              }
+            }
+          },
+          "url": {
+            "type": "string",
+            "description": "e.g. http://xyz.example.com - [Related link to the company website]",
+            "format": "uri"
+          },
+          "startDate": {
+            "type": "string",
+            "description": "e.g. 2017-06-28 - [resume.json uses the ISO 8601 date standard]",
+            "format": "date"
+          },
+          "endDate": {
+            "type": "string",
+            "description": "e.g. 2018-12-29 - [resume.json uses the ISO 8601 date standard]",
+            "format": "date"
+          },
+          "summary": {
+            "type": "string",
+            "description": "Give an overview of your responsibilities at the company"
+          },
+          "highlights": {
+            "type": "array",
+            "description": "Specify multiple accomplishments",
+            "additionalItems": false,
+            "items": {
+              "type": "string",
+              "description": "e.g. Worked with mobile team at Twitter to develop remote debugging tools for mobile browsers "
+            }
+          }
+        }
+      }
+    },
+    "education": {
+      "type": "array",
+      "additionalItems": false,
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "institution": {
+            "type": "string",
+            "description": "e.g. XYZ Institute of Technology - [Add institute name]"
+          },
+          "location": {
+            "type": "object",
+            "format": "location",
+            "description": "e.g. Germany - [Location for this institution]",
+            "properties": {
+              "lat": {
+                "type": "number"
+              },
+              "long": {
+                "type": "number"
+              }
+            }
+          },
+          "area": {
+            "type": "string",
+            "description": "e.g. Engineering"
+          },
+          "studyType": {
+            "type": "string",
+            "description": "e.g. Bachelor"
+          },
+          "startDate": {
+            "type": "string",
+            "description": "e.g. 2017-06-29 - [resume.json uses the ISO 8601 date standard]",
+            "format": "date"
+          },
+          "endDate": {
+            "type": "string",
+            "description": "e.g. 2013-06-29 - [resume.json uses the ISO 8601 date standard]",
+            "format": "date"
+          },
+          "score": {
+            "type": "object",
+            "additionalProperties": true,
+            "properties": {
+              "scoretype": {
+                "type": "string",
+                "description": "eg. GPA or PERCENTAGE - [Add score type]"
+              },
+              "scorevalue": {
+                "type": "string",
+                "description": "eg. 3.4/4.0 - [Add obtained score/total score]"
+              }
+            }
+          },
+          "courses": {
+            "type": "array",
+            "description": "List notable courses/subjects",
+            "additionalItems": false,
+            "items": {
+              "type": "string",
+              "description": "e.g. CS302 - Introduction to Algorithms - [Add course name]"
+            }
+          },
+          "honors": {
+            "type": "array",
+            "description": "List education honours",
+            "additionalItems": false,
+            "items": {
+              "type": "string",
+              "description": "e.g. Magna Cum Laude"
+            }
+          }
+        }
+      }
+    },
+    "volunteer": {
+      "type": "array",
+      "additionalItems": false,
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "organization": {
+            "type": "string",
+            "description": "e.g. Xyz "
+          },
+          "position": {
+            "type": "string",
+            "description": "e.g. Open Source Contributor - [Contribution type]"
+          },
+          "location": {
+            "type": "object",
+            "format": "location",
+            "description": "e.g. Germany - [Location for this activity]",
+            "properties": {
+              "lat": {
+                "type": "number"
+              },
+              "long": {
+                "type": "number"
+              }
+            }
+          },
+          "url": {
+            "type": "string",
+            "description": "e.g. http://xyz.example.com - [Related link to support volunteer experience]",
+            "format": "uri"
+          },
+          "startDate": {
+            "type": "string",
+            "description": "e.g. 2014-06-29 - [resume.json uses the ISO 8601 date standard]",
+            "format": "date"
+          },
+          "endDate": {
+            "type": "string",
+            "description": "e.g. 2017-06-29 - [resume.json uses the ISO 8601 date standard] ",
+            "format": "date"
+          },
+          "summary": {
+            "type": "string",
+            "description": "Give an overview of your responsibilities at the company"
+          },
+          "highlights": {
+            "type": "array",
+            "description": "Specify accomplishments and achievements",
+            "additionalItems": false,
+            "items": {
+              "type": "string",
+              "description": "e.g Invited as a speaker in Xyzcon'17"
+            }
+          }
+        }
+      }
+    },
+    "publications": {
+      "type": "array",
+      "description": "Specify your publications",
+      "additionalItems": false,
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "e.g. Deep learning and Artificial Intelligence"
+          },
+          "publisher": {
+            "type": "string",
+            "description": "e.g. XYZ, Computer Magazine"
+          },
+          "releaseDate": {
+            "type": "string",
+            "description": "e.g. 2015-08-01 - [resume.json uses the ISO 8601 date standard]"
+          },
+          "resources": {
+            "type": "array",
+            "description": "Specify multiple resources with label",
+            "additionalItems": false,
+            "url": {
+              "type": "string",
+              "format": "uri",
+              "description": "e.g. http://www.example.com/my-example-slides/"
+            },
+            "label": {
+              "type": "string",
+              "description": "e.g Slides"
+            }
+          },
+          "url": {
+            "type": "string",
+            "format": "uri",
+            "description": "e.g. http://www.computer.org.example.com/csdl/mags/co/2015/10/rx069-abs.html"
+          },
+          "summary": {
+            "type": "string",
+            "description": "e.g. Discussion of the advent of deep learning and artificial intelligence - [Short summary of publication]"
+          }
+        }
+      }
+    },
+    "legal": {
+      "type": "array",
+      "description": "Specify your labels",
+      "additionalItems": false,
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "e.g. XYZ's patent on LZW compression, a fundamental part of the widely used GIF graphics format - [Add document name]"
+          },
+          "legalType": {
+            "type": "string",
+            "description": "e.g. Patent, Trademark, Copyright - [Give the type of this document]"
+          },
+          "description": {
+            "type": "string",
+            "description": "Give a brief description about this document"
+          },
+          "applicationDate": {
+            "type": "string",
+            "description": "e.g. 2015-08-01 - [resume.json uses the ISO 8601 date standard]",
+            "format": "date"
+          },
+          "grantDate": {
+            "type": "string",
+            "description": "e.g. 2016-09-01 - [resume.json uses the ISO 8601 date standard]",
+            "format": "date"
+          },
+          "endDate": {
+            "type": "string",
+            "description": "e.g. 2020-09-03 - [resume.json uses the ISO 8601 date standard]",
+            "format": "date"
+          },
+          "resources": {
+            "type": "array",
+            "description": "Specify multiple resources with label",
+            "additionalItems": false,
+            "url": {
+              "type": "string",
+              "format": "uri",
+              "description": "e.g. http://www.example.com/my-patent-slides/"
+            },
+            "label": {
+              "type": "string",
+              "description": "e.g Slides"
+            }
+          },
+          "idNumber": {
+            "type": "string",
+            "description": "e.g. JP2004369746A - [Add the application number or Id Number]  "
+          }
+        }
+      }
+    },
+    "skills": {
+      "type": "array",
+      "description": "List out your professional skill-set",
+      "additionalItems": false,
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "e.g. Web Development"
+          },
+          "keyword": {
+            "type": "array",
+            "description": "List some keywords pertaining to the skill",
+            "additionalItems": false,
+            "items": {
+              "type": "object",
+              "additionalProperties": true,
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "description": "e.g. HTML - [Add the skill name]"
+                },
+                "score": {
+                  "type": "number",
+                  "description": "e.g. 20 - [Score for the skill name]"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "awards": {
+      "type": "array",
+      "description": "Specify any awards you have received throughout your professional career",
+      "additionalItems": false,
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "title": {
+            "type": "string",
+            "description": "e.g. Awarded Software Process Achievement Award "
+          },
+          "date": {
+            "type": "string",
+            "description": "e.g. 2016-06-12 - [resume.json uses the ISO 8601 date standard]",
+            "format": "date"
+          },
+          "awarder": {
+            "type": "string",
+            "description": "e.g. IEEE"
+          },
+          "summary": {
+            "type": "string",
+            "description": "e.g. Received for my work in Deep learning and AI"
+          }
+        }
+      }
+    },
+    "projects": {
+      "type": "array",
+      "description": "Specify career projects",
+      "additionalItems": false,
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "e.g. File Transfer application - [Name of the project]"
+          },
+          "location": {
+            "type": "object",
+            "format": "location",
+            "description": "e.g France - [Location for this activity]",
+            "properties": {
+              "lat": {
+                "type": "number"
+              },
+              "long": {
+                "type": "number"
+              }
+            }
+          },
+          "description": {
+            "type": "string",
+            "description": "e.g. Developed a client and server based application - [Short summary of project]"
+          },
+          "highlights": {
+            "type": "array",
+            "description": "Specify multiple features",
+            "additionalItems": false,
+            "items": {
+              "type": "string",
+              "description": "e.g. used Java AWT and Swing for client side userinterface"
+            }
+          },
+          "keywords": {
+            "type": "array",
+            "description": "Specify special elements involved",
+            "additionalItems": false,
+            "items": {
+              "type": "string",
+              "description": "e.g. Java"
+            }
+          },
+          "startDate": {
+            "type": "string",
+            "description": "e.g. 2017-06-29 - [resume.json uses the ISO 8601 date standard]",
+            "format": "date"
+          },
+          "endDate": {
+            "type": "string",
+            "description": "e.g. 2017-06-29 - [resume.json uses the ISO 8601 date standard] ",
+            "format": "date"
+          },
+          "resources": {
+            "type": "array",
+            "description": "Specify multiple resources with label",
+            "additionalItems": false,
+            "url": {
+              "type": "string",
+              "format": "uri",
+              "description": "e.g. http://www.example.com/my-awesome-slides/"
+            },
+            "label": {
+              "type": "string",
+              "description": "e.g slides"
+            }
+          },
+          "url": {
+            "type": "string",
+            "format": "uri",
+            "description": "e.g. http://www.example.org/csdl/mags/co/1996/10/rx069-abs.html"
+          },
+          "roles": {
+            "type": "array",
+            "description": "Specify your role on this project or in company",
+            "additionalItems": false,
+            "items": {
+              "type": "string",
+              "description": "e.g. Team Lead, Speaker, Writer"
+            }
+          },
+          "entity": {
+            "type": "string",
+            "description": "e.g. 'greenpeace', 'corporationXYZ' - [Relevant company/entity affiliations]"
+          },
+          "type": {
+            "type": "string",
+            "description": "e.g. 'volunteering', 'presentation', 'talk', 'application', 'conference'"
+          }
+        }
+      }
+    },
+    "certificates": {
+      "type": "array",
+      "additionalItems": false,
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "code": {
+            "type": "string",
+            "description": "e.g. 1Z0-062"
+          },
+          "name": {
+            "type": "string",
+            "description": "e.g. XYZ Certified Application Specialist (MCAS) - [Add the certificate name]"
+          },
+          "website": {
+            "type": "string",
+            "description": "Link to issuing authority's description of the certificate",
+            "format": "uri"
+          },
+          "verification": {
+            "type": "string",
+            "description": "External candidate verification URL",
+            "format": "uri"
+          },
+          "grantDate": {
+            "type": "string",
+            "description": "e.g. 2017-06-29 - [resume.json uses the ISO 8601 date standard]",
+            "format": "date"
+          },
+          "score": {
+            "type": "string",
+            "description": "e.g. 95% - [Exam result (PASS/FAIL, 100%, 100)]"
+          },
+          "endDate": {
+            "type": "string",
+            "description": "e.g. 2020-01-20",
+            "format": "date"
+          },
+          "doesNotExpire": {
+            "type": "boolean",
+            "format": "checkbox"
+          }
+        }
+      }
+    },
+    "references": {
+      "type": "array",
+      "description": "List references you have received",
+      "additionalItems": false,
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "e.g. Stephan Mark"
+          },
+          "company": {
+            "type": "string",
+            "description": "e.g. Xyz"
+          },
+          "position": {
+            "type": "string",
+            "description": "e.g. Senior Software Engineer"
+          },
+          "reference": {
+            "type": "string",
+            "description": "e.g. Joe blogs was a great employee, who turned up to work at least once a week. He exceeded my expectations when it came to doing nothing."
+          }
+        }
+      }
+    },
+    "languages": {
+      "type": "array",
+      "description": "List any other languages you speak",
+      "additionalItems": false,
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "language": {
+            "type": "string",
+            "description": "e.g. English - [Name of language]"
+          },
+          "score": {
+            "type": "number",
+            "description": "e.g. 20 - [Score for the language]"
+          }
+        }
+      }
+    },
+    "interests": {
+      "type": "array",
+      "additionalItems": false,
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "e.g. Machine Learning"
+          }
+        },
+          "keywords": {
+            "type": "array",
+            "description": "Specify keywords associated with the particular interest",
+            "additionalItems": false,
+            "items": {
+              "type": "string",
+              "description": "e.g. Neural Networks, Convoluted Neural Networks"
+            }
+          }
+        }
+      },
+    "meta": {
+      "type": "object",
+      "description": "The schema version and any other tooling configuration lives here",
+      "additionalProperties": true,
+      "properties": {
+        "canonical": {
+          "type": "string",
+          "description": "URL (as per RFC 3986) to latest version of this document"
+        },
+        "version": {
+          "type": "string",
+          "description": "e.g. v1.0.0 - [A version field which follows semver]"
+        },
+        "lastModified": {
+          "type": "string",
+          "description": "e.g. 2017-06-29T15:53:00 - [resume.json uses the ISO 8601 date standard]",
+          "format": "date"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Implements a new package called ``schema`` that is used for generating the schema.json file and validations.
  

**Which issue this PR fixes**:
fixes #56 