### PR TITLE
feat: Add $schema property to schema

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -687,6 +687,17 @@
       },
       "type": "array"
     },
+    "$schema": {
+      "type": "string",
+      "format": "uri",
+      "title": "JSON Schema to use",
+      "default": "http://json.schemastore.org/resumic-schema.json",
+      "description": "Editors like VS Code use this schema for validation and triggering suggestions when editing resumic JSON files.",
+      "examples": [
+        "http://json.schemastore.org/resumic-schema.json",
+        "https://raw.githubusercontent.com/resumic/schema/master/schema.json"
+      ]
+    },
     "skills": {
       "description": "list of professional skill-sets",
       "items": {


### PR DESCRIPTION
**What this PR does / why we need it**:

VS Code supports [code completion for JSON files](https://code.visualstudio.com/docs/languages/json) based on [JSON Schema](https://json-schema.org/specification.html).

Code completion in VS Code picks up a schema for any JSON file if the schema is
specified as `"$schema": "<URL to schema>"`.

It automatically picks up [certain JSON Schemas](https://code.visualstudio.com/docs/languages/json#_json-schemas-and-settings) by file name (ie: `package.json`) and you can configure your own associations via (workspace) `settings.json` like this:

```json
"json.schemas": [
  {
    "fileMatch": [
      "resume.json"
    ],
    "url": "http://json.schemastore.org/resumic-schema.json"
  }
]
```

Alternatively VS Code supports the `$schema` key in JSON files itself.

So in a `resume.json` we could add the [JSON Resumic schema](http://json.schemastore.org/resumic-schema.json) to get code completion without touching the VS Code settings:

```json
{
  "$schema": "http://json.schemastore.org/resumic-schema.json",

}
```

[XML](https://www.w3.org/TR/2008/REC-xml-20081126/) had a similar feature where you could specify an [XSD](https://www.w3.org/TR/xmlschema-0/) in the XML pre-processing tags to validate the syntax and data (to some extent) of the XML.

**Release note**:

```release-note
Add `$schema` property to resumic JSON schema to allow editors like VS Code to offer validation and triggering suggestions.
```
